### PR TITLE
F-006: Question flow component with 5 step types

### DIFF
--- a/src/components/shared/QuestionFlow.test.tsx
+++ b/src/components/shared/QuestionFlow.test.tsx
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import QuestionFlow from "./QuestionFlow";
+import type { QuestionFlowStep } from "./QuestionStep";
+
+// ============================================================================
+// TEST DATA
+// ============================================================================
+
+const mockSteps: QuestionFlowStep[] = [
+  {
+    id: "business-type",
+    type: "choice",
+    question: "What type of business do you run?",
+    description: "This helps us tailor your compliance checklist.",
+    options: [
+      { value: "sole-trader", label: "Sole trader", icon: "user" },
+      { value: "limited", label: "Limited company", icon: "briefcase" },
+      { value: "partnership", label: "Partnership", icon: "users" },
+    ],
+  },
+  {
+    id: "headcount",
+    type: "number-picker",
+    question: "How many people work in your business?",
+    options: [
+      { value: "1", label: "Just me" },
+      { value: "2-4", label: "2-4" },
+      { value: "5-9", label: "5-9" },
+      { value: "10+", label: "10+" },
+    ],
+  },
+  {
+    id: "vat-registered",
+    type: "yes-no-unsure",
+    question: "Are you VAT registered?",
+    tooltip: "If your turnover is over £85,000 you must register for VAT.",
+  },
+  {
+    id: "sector",
+    type: "searchable-list",
+    question: "What sector is your business in?",
+    searchItems: [
+      "Retail",
+      "Construction",
+      "Technology",
+      "Healthcare",
+      "Hospitality",
+      "Professional Services",
+    ],
+  },
+  {
+    id: "trading-start",
+    type: "month-year-picker",
+    question: "When did you start trading?",
+    skipLabel: "We haven't started yet",
+    required: false,
+  },
+];
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe("QuestionFlow", () => {
+  it("renders first step with correct question text", () => {
+    render(
+      <QuestionFlow steps={mockSteps} onComplete={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText("What type of business do you run?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("This helps us tailor your compliance checklist.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows title when provided", () => {
+    render(
+      <QuestionFlow
+        steps={mockSteps}
+        onComplete={vi.fn()}
+        title="Set up your business"
+      />
+    );
+
+    expect(screen.getByText("Set up your business")).toBeInTheDocument();
+  });
+
+  it("progress bar shows correct step count", () => {
+    render(
+      <QuestionFlow steps={mockSteps} onComplete={vi.fn()} />
+    );
+
+    expect(screen.getByText("Step 1 of 5")).toBeInTheDocument();
+  });
+
+  it("selecting an option updates internal state", () => {
+    render(
+      <QuestionFlow steps={mockSteps} onComplete={vi.fn()} />
+    );
+
+    const soleTraderBtn = screen.getByText("Sole trader").closest("button")!;
+    fireEvent.click(soleTraderBtn);
+
+    expect(soleTraderBtn).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("back button navigates to previous step", () => {
+    vi.useFakeTimers();
+    const onStepChange = vi.fn();
+
+    render(
+      <QuestionFlow
+        steps={mockSteps}
+        onComplete={vi.fn()}
+        onStepChange={onStepChange}
+      />
+    );
+
+    // Select an option to auto-advance
+    fireEvent.click(screen.getByText("Sole trader").closest("button")!);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(
+      screen.getByText("How many people work in your business?")
+    ).toBeInTheDocument();
+
+    // Click back
+    fireEvent.click(screen.getByLabelText("Go back"));
+
+    expect(
+      screen.getByText("What type of business do you run?")
+    ).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("does not show back button on first step", () => {
+    render(
+      <QuestionFlow steps={mockSteps} onComplete={vi.fn()} />
+    );
+
+    expect(screen.queryByLabelText("Go back")).not.toBeInTheDocument();
+  });
+
+  it("onComplete is called with all answers when last step is completed", () => {
+    vi.useFakeTimers();
+    const onComplete = vi.fn();
+
+    // Use a minimal 2-step flow for simplicity
+    const twoSteps: QuestionFlowStep[] = [
+      {
+        id: "q1",
+        type: "yes-no-unsure",
+        question: "First question?",
+      },
+      {
+        id: "q2",
+        type: "yes-no-unsure",
+        question: "Second question?",
+      },
+    ];
+
+    render(<QuestionFlow steps={twoSteps} onComplete={onComplete} />);
+
+    // Answer first question
+    fireEvent.click(screen.getByText("Yes").closest("button")!);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText("Second question?")).toBeInTheDocument();
+
+    // Answer second question
+    fireEvent.click(screen.getByText("No").closest("button")!);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({
+      q1: "yes",
+      q2: "no",
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("skip button works when configured", () => {
+    vi.useFakeTimers();
+    const onComplete = vi.fn();
+
+    const skippableSteps: QuestionFlowStep[] = [
+      {
+        id: "optional-q",
+        type: "month-year-picker",
+        question: "When did you start?",
+        skipLabel: "We haven't started yet",
+        required: false,
+      },
+    ];
+
+    render(
+      <QuestionFlow steps={skippableSteps} onComplete={onComplete} />
+    );
+
+    // The skip button is rendered inside the MonthYearPickerStep
+    const skipBtn = screen.getByText("We haven't started yet");
+    expect(skipBtn).toBeInTheDocument();
+
+    fireEvent.click(skipBtn);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({
+      "optional-q": "skipped",
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("renders searchable list with search input", () => {
+    // Start directly at the searchable-list step using initialAnswers to advance
+    const searchStep: QuestionFlowStep[] = [
+      {
+        id: "sector",
+        type: "searchable-list",
+        question: "What sector is your business in?",
+        searchItems: ["Retail", "Construction", "Technology"],
+      },
+    ];
+
+    render(
+      <QuestionFlow steps={searchStep} onComplete={vi.fn()} />
+    );
+
+    expect(screen.getByPlaceholderText("Start typing to search...")).toBeInTheDocument();
+    expect(screen.getByText("Retail")).toBeInTheDocument();
+    expect(screen.getByText("Construction")).toBeInTheDocument();
+    expect(screen.getByText("Technology")).toBeInTheDocument();
+  });
+
+  it("searchable list filters items based on input", () => {
+    const searchStep: QuestionFlowStep[] = [
+      {
+        id: "sector",
+        type: "searchable-list",
+        question: "Pick a sector",
+        searchItems: ["Retail", "Construction", "Technology"],
+      },
+    ];
+
+    render(
+      <QuestionFlow steps={searchStep} onComplete={vi.fn()} />
+    );
+
+    const input = screen.getByPlaceholderText("Start typing to search...");
+    fireEvent.change(input, { target: { value: "tech" } });
+
+    expect(screen.getByText("Technology")).toBeInTheDocument();
+    expect(screen.queryByText("Retail")).not.toBeInTheDocument();
+    expect(screen.queryByText("Construction")).not.toBeInTheDocument();
+  });
+
+  it("renders tooltip trigger when tooltip is configured", () => {
+    const tooltipSteps: QuestionFlowStep[] = [
+      {
+        id: "q",
+        type: "yes-no-unsure",
+        question: "Are you VAT registered?",
+        tooltip: "Some helpful info here.",
+      },
+    ];
+
+    render(
+      <QuestionFlow steps={tooltipSteps} onComplete={vi.fn()} />
+    );
+
+    expect(screen.getByText("Not sure? Tap here")).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/QuestionFlow.tsx
+++ b/src/components/shared/QuestionFlow.tsx
@@ -1,0 +1,288 @@
+// src/components/shared/QuestionFlow.tsx
+// Reusable multi-step question flow with progress tracking.
+// Designed for non-technical users: large tap targets, plain English, one question per screen.
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { Button, ProgressBar, AppIcon } from "@/components/ui";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import QuestionStep from "./QuestionStep";
+import type { QuestionFlowStep } from "./QuestionStep";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type { QuestionFlowStep, ChoiceOption } from "./QuestionStep";
+
+export interface QuestionFlowProps {
+  steps: QuestionFlowStep[];
+  onComplete: (answers: Record<string, string>) => void;
+  onStepChange?: (stepIndex: number) => void;
+  initialAnswers?: Record<string, string>;
+  title?: string;
+  className?: string;
+}
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Auto-advance types get a brief delay for visual feedback */
+const AUTO_ADVANCE_TYPES = new Set(["choice", "number-picker", "yes-no-unsure"]);
+const AUTO_ADVANCE_DELAY_MS = 400;
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+export default function QuestionFlow({
+  steps,
+  onComplete,
+  onStepChange,
+  initialAnswers = {},
+  title,
+  className,
+}: QuestionFlowProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>(initialAnswers);
+  const [direction, setDirection] = useState<"forward" | "backward">("forward");
+  const autoAdvanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  const currentStep = steps[currentIndex];
+  const isFirstStep = currentIndex === 0;
+  const isLastStep = currentIndex === steps.length - 1;
+  const currentValue = answers[currentStep?.id] ?? "";
+  const isRequired = currentStep?.required !== false;
+  const hasAnswer = currentValue.length > 0;
+  const canProceed = hasAnswer || !isRequired;
+
+  // Notify parent of step changes
+  useEffect(() => {
+    onStepChange?.(currentIndex);
+  }, [currentIndex, onStepChange]);
+
+  // Cleanup auto-advance timer on unmount
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
+    };
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !isFirstStep) {
+        goBack();
+      }
+      if (e.key === "Enter" && canProceed) {
+        goForward();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, canProceed, isFirstStep]);
+
+  const goBack = useCallback(() => {
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+      autoAdvanceTimer.current = null;
+    }
+    setDirection("backward");
+    setCurrentIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const goForward = useCallback(() => {
+    if (isLastStep) {
+      onComplete(answers);
+    } else {
+      setDirection("forward");
+      setCurrentIndex((i) => Math.min(steps.length - 1, i + 1));
+    }
+  }, [isLastStep, answers, onComplete, steps.length]);
+
+  const handleAnswerChange = useCallback(
+    (value: string) => {
+      const updated = { ...answers, [currentStep.id]: value };
+      setAnswers(updated);
+
+      // Auto-advance for selection types or skip actions
+      if (AUTO_ADVANCE_TYPES.has(currentStep.type) || value === "skipped") {
+        if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
+
+        const delay = prefersReducedMotion ? 0 : AUTO_ADVANCE_DELAY_MS;
+        autoAdvanceTimer.current = setTimeout(() => {
+          if (isLastStep) {
+            onComplete(updated);
+          } else {
+            setDirection("forward");
+            setCurrentIndex((i) => Math.min(steps.length - 1, i + 1));
+          }
+        }, delay);
+      }
+    },
+    [answers, currentStep, isLastStep, onComplete, steps.length, prefersReducedMotion]
+  );
+
+  const handleSkip = useCallback(() => {
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+      autoAdvanceTimer.current = null;
+    }
+    const updated = { ...answers, [currentStep.id]: "skipped" };
+    setAnswers(updated);
+
+    if (isLastStep) {
+      onComplete(updated);
+    } else {
+      setDirection("forward");
+      setCurrentIndex((i) => Math.min(steps.length - 1, i + 1));
+    }
+  }, [answers, currentStep, isLastStep, onComplete, steps.length]);
+
+  if (!currentStep) return null;
+
+  const progressPercent = ((currentIndex + 1) / steps.length) * 100;
+  // month-year-picker has its own skip button built into the step
+  const showSkip =
+    currentStep.type !== "month-year-picker" &&
+    (!isRequired || currentStep.skipLabel);
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-lg mx-auto flex flex-col min-h-0",
+        className
+      )}
+    >
+      {/* Header: title + progress */}
+      <div className="flex flex-col gap-2 mb-6">
+        {title && (
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        )}
+        <ProgressBar
+          value={progressPercent}
+          color="primary"
+          size="md"
+          label={`Step ${currentIndex + 1} of ${steps.length}`}
+        />
+      </div>
+
+      {/* Question area */}
+      <div
+        className={cn(
+          "flex-1 flex flex-col",
+          !prefersReducedMotion && "transition-opacity duration-200",
+          !prefersReducedMotion && direction === "forward" && "animate-slide-up",
+        )}
+        key={currentStep.id}
+      >
+        {/* Question text */}
+        <div className="mb-6">
+          <h3 className="text-2xl font-bold text-foreground leading-tight">
+            {currentStep.question}
+          </h3>
+          {currentStep.description && (
+            <p className="mt-2 text-base text-muted-foreground">
+              {currentStep.description}
+            </p>
+          )}
+        </div>
+
+        {/* Step content */}
+        <QuestionStep
+          step={currentStep}
+          value={currentValue}
+          onChange={handleAnswerChange}
+        />
+
+        {/* Tooltip */}
+        {currentStep.tooltip && (
+          <div className="mt-4">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      "inline-flex items-center gap-1.5 text-sm text-muted-foreground",
+                      "hover:text-foreground transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                    )}
+                  >
+                    <AppIcon name="question" className="w-4 h-4" />
+                    <span>Not sure? Tap here</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  <p>{currentStep.tooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="mt-8 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          {/* Back button */}
+          {!isFirstStep ? (
+            <Button
+              variant="ghost"
+              size="md"
+              leftIcon="arrow-left"
+              onClick={goBack}
+              aria-label="Go back"
+            >
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
+
+          {/* Next / Complete button (only for non-auto-advance types) */}
+          {!AUTO_ADVANCE_TYPES.has(currentStep.type) && (
+            <Button
+              variant="primary"
+              size="md"
+              rightIcon="arrow-right"
+              onClick={goForward}
+              disabled={!canProceed}
+              aria-label={isLastStep ? "Complete" : "Next"}
+            >
+              {isLastStep ? "Complete" : "Next"}
+            </Button>
+          )}
+        </div>
+
+        {/* Skip button */}
+        {showSkip && (
+          <button
+            type="button"
+            onClick={handleSkip}
+            className={cn(
+              "w-full min-h-[44px] px-4 py-2 rounded-xl",
+              "text-sm text-muted-foreground hover:text-foreground",
+              "border border-dashed border-border hover:bg-accent/50",
+              "transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            )}
+          >
+            {currentStep.skipLabel ?? "Skip this question"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/QuestionStep.tsx
+++ b/src/components/shared/QuestionStep.tsx
@@ -1,0 +1,395 @@
+// src/components/shared/QuestionStep.tsx
+// Individual step renderer supporting 5 question types for the QuestionFlow.
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { AppIcon, Input } from "@/components/ui";
+import type { IconKey } from "@/components/ui/AppIcon";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface ChoiceOption {
+  value: string;
+  label: string;
+  icon?: string;
+  description?: string;
+}
+
+export interface QuestionFlowStep {
+  id: string;
+  type:
+    | "choice"
+    | "number-picker"
+    | "yes-no-unsure"
+    | "searchable-list"
+    | "month-year-picker";
+  question: string;
+  description?: string;
+  tooltip?: string;
+  required?: boolean;
+  options?: ChoiceOption[];
+  searchItems?: string[];
+  skipLabel?: string;
+}
+
+interface QuestionStepProps {
+  step: QuestionFlowStep;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+// ============================================================================
+// SHARED OPTION BUTTON
+// ============================================================================
+
+function OptionButton({
+  selected,
+  onClick,
+  children,
+  className,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={onClick}
+      className={cn(
+        "w-full min-h-[56px] px-4 py-3 rounded-xl border text-left",
+        "font-medium text-foreground transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        selected
+          ? "border-primary bg-primary/5 ring-1 ring-primary/30"
+          : "border-border bg-background hover:bg-accent/50",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ============================================================================
+// STEP TYPE: CHOICE
+// ============================================================================
+
+function ChoiceStep({
+  step,
+  value,
+  onChange,
+}: QuestionStepProps) {
+  return (
+    <div className="flex flex-col gap-3" role="listbox" aria-label={step.question}>
+      {step.options?.map((option) => (
+        <OptionButton
+          key={option.value}
+          selected={value === option.value}
+          onClick={() => onChange(option.value)}
+        >
+          <div className="flex items-center gap-3">
+            {option.icon && (
+              <AppIcon
+                name={option.icon as IconKey}
+                className="w-5 h-5 text-primary shrink-0"
+              />
+            )}
+            <div className="flex flex-col">
+              <span className="text-base">{option.label}</span>
+              {option.description && (
+                <span className="text-sm text-muted-foreground mt-0.5">
+                  {option.description}
+                </span>
+              )}
+            </div>
+          </div>
+        </OptionButton>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// STEP TYPE: NUMBER PICKER
+// ============================================================================
+
+function NumberPickerStep({
+  step,
+  value,
+  onChange,
+}: QuestionStepProps) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:gap-3"
+      role="listbox"
+      aria-label={step.question}
+    >
+      {step.options?.map((option) => (
+        <OptionButton
+          key={option.value}
+          selected={value === option.value}
+          onClick={() => onChange(option.value)}
+          className="text-center justify-center"
+        >
+          <div className="flex flex-col items-center gap-1">
+            {option.icon && (
+              <AppIcon
+                name={option.icon as IconKey}
+                className="w-5 h-5 text-primary"
+              />
+            )}
+            <span className="text-base font-semibold">{option.label}</span>
+            {option.description && (
+              <span className="text-xs text-muted-foreground">
+                {option.description}
+              </span>
+            )}
+          </div>
+        </OptionButton>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// STEP TYPE: YES / NO / UNSURE
+// ============================================================================
+
+const YES_NO_UNSURE_OPTIONS: ChoiceOption[] = [
+  { value: "yes", label: "Yes" },
+  { value: "no", label: "No" },
+  { value: "unsure", label: "Not sure" },
+];
+
+function YesNoUnsureStep({
+  step,
+  value,
+  onChange,
+}: QuestionStepProps) {
+  return (
+    <div className="flex flex-col gap-3" role="listbox" aria-label={step.question}>
+      {YES_NO_UNSURE_OPTIONS.map((option) => (
+        <OptionButton
+          key={option.value}
+          selected={value === option.value}
+          onClick={() => onChange(option.value)}
+          className="text-center justify-center"
+        >
+          <span className="text-base font-semibold">{option.label}</span>
+        </OptionButton>
+      ))}
+      {value === "unsure" && (
+        <p className="text-sm text-muted-foreground text-center mt-1">
+          That&apos;s fine &mdash; you can update this later.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// STEP TYPE: SEARCHABLE LIST
+// ============================================================================
+
+function SearchableListStep({
+  step,
+  value,
+  onChange,
+}: QuestionStepProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    const items = step.searchItems ?? [];
+    if (!query.trim()) return items;
+    const q = query.toLowerCase();
+    return items.filter((item) => item.toLowerCase().includes(q));
+  }, [step.searchItems, query]);
+
+  // Focus the search input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Input
+        ref={inputRef}
+        type="text"
+        placeholder="Start typing to search..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full"
+        aria-label="Search options"
+      />
+      <div
+        className="flex flex-col gap-2 max-h-[320px] overflow-y-auto"
+        role="listbox"
+        aria-label={step.question}
+      >
+        {filtered.map((item) => (
+          <OptionButton
+            key={item}
+            selected={value === item}
+            onClick={() => onChange(item)}
+            className="min-h-[44px]"
+          >
+            <span className="text-base">{item}</span>
+          </OptionButton>
+        ))}
+        {/* "Other" always visible */}
+        {!filtered.includes("Other") && (
+          <OptionButton
+            selected={value === "Other"}
+            onClick={() => onChange("Other")}
+            className="min-h-[44px] border-dashed"
+          >
+            <span className="text-base text-muted-foreground">Other</span>
+          </OptionButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// STEP TYPE: MONTH-YEAR PICKER
+// ============================================================================
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function MonthYearPickerStep({
+  step,
+  value,
+  onChange,
+}: QuestionStepProps) {
+  // value format: "YYYY-MM" or ""
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(() => {
+    if (value && value.includes("-")) return parseInt(value.split("-")[1], 10) - 1;
+    return null;
+  });
+  const [selectedYear, setSelectedYear] = useState<number | null>(() => {
+    if (value && value.includes("-")) return parseInt(value.split("-")[0], 10);
+    return null;
+  });
+
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 11 }, (_, i) => currentYear - i);
+
+  const handleMonthSelect = useCallback(
+    (monthIdx: number) => {
+      setSelectedMonth(monthIdx);
+      if (selectedYear !== null) {
+        const mm = String(monthIdx + 1).padStart(2, "0");
+        onChange(`${selectedYear}-${mm}`);
+      }
+    },
+    [selectedYear, onChange]
+  );
+
+  const handleYearSelect = useCallback(
+    (year: number) => {
+      setSelectedYear(year);
+      if (selectedMonth !== null) {
+        const mm = String(selectedMonth + 1).padStart(2, "0");
+        onChange(`${year}-${mm}`);
+      }
+    },
+    [selectedMonth, onChange]
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Month grid */}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-2">Month</p>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4" role="listbox" aria-label="Select month">
+          {MONTHS.map((m, idx) => (
+            <OptionButton
+              key={m}
+              selected={selectedMonth === idx}
+              onClick={() => handleMonthSelect(idx)}
+              className="min-h-[44px] text-center justify-center"
+            >
+              <span className="text-sm font-medium">{m}</span>
+            </OptionButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Year buttons */}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-2">Year</p>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4" role="listbox" aria-label="Select year">
+          {years.map((y) => (
+            <OptionButton
+              key={y}
+              selected={selectedYear === y}
+              onClick={() => handleYearSelect(y)}
+              className="min-h-[44px] text-center justify-center"
+            >
+              <span className="text-sm font-medium">{y}</span>
+            </OptionButton>
+          ))}
+        </div>
+      </div>
+
+      {/* Skip option */}
+      {step.skipLabel && (
+        <button
+          type="button"
+          onClick={() => onChange("skipped")}
+          className={cn(
+            "w-full min-h-[44px] px-4 py-3 rounded-xl border border-dashed border-border",
+            "text-sm text-muted-foreground hover:bg-accent/50 transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          )}
+        >
+          {step.skipLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// MAIN EXPORT
+// ============================================================================
+
+export default function QuestionStep(props: QuestionStepProps) {
+  const { step } = props;
+
+  switch (step.type) {
+    case "choice":
+      return <ChoiceStep {...props} />;
+    case "number-picker":
+      return <NumberPickerStep {...props} />;
+    case "yes-no-unsure":
+      return <YesNoUnsureStep {...props} />;
+    case "searchable-list":
+      return <SearchableListStep {...props} />;
+    case "month-year-picker":
+      return <MonthYearPickerStep {...props} />;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Reusable `QuestionFlow` + `QuestionStep` components for multi-step forms
- 5 step types: choice, number-picker, yes-no-unsure, searchable-list, month-year-picker
- Single question per screen with progress bar (PRD design principle)
- Large tap targets (56px min), auto-advance on selection, keyboard navigation
- Back button always visible, skip/unsure options, prefers-reduced-motion support
- 11 new unit tests

Closes #10

## Checks
- **Lint**: clean | **Tests**: 17/17 pass (11 new) | **Build**: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)