### PR TITLE
F-023: Landing page with 7 sections and 10 reusable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Full landing page with 7 sections matching UX design (F-023): Hero, Trust Strip, Problem, How It Works, Pricing, Final CTA, Footer
+- 8 reusable landing components: LandingNav, HeroHealthCard, EmailSignup, TrustBadges, StatStrip, SectionHeader, FeatureCard, NumberedStep, PricingCard, LandingFooter
+- Landing page renders outside PublicLayout (full-width with own nav)
 - Reusable `RagStatus` component with 4 variants: dot, badge, card, large (F-004)
 - WCAG 2.1 AA compliant — every variant pairs colour with text label + icon
 - Core database schema (Migration 001) with 13 tables, RLS policies, indexes, and updated_at triggers

--- a/docs/ux-reference/landing-page.html
+++ b/docs/ux-reference/landing-page.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <script>
+        window.FontAwesomeConfig = {
+          autoReplaceSvg: 'nest'
+        };
+      </script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RUCompliant | Landing Page</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Manrope', 'sans-serif'],
+                    },
+                    colors: {
+                        brand: {
+                            black: '#000000',
+                            porcelain: '#FFFFFC',
+                            magenta: '#E43F6F',
+                            magentahover: '#CC2255',
+                            duskblue: '#345995',
+                            emerald: '#48BF84',
+                            surface: '#F5F5F2',
+                            muted: '#888888',
+                            border: '#E5E5E0',
+                        },
+                        rag: {
+                            green: { border: '#48BF84', bg: '#EBF9F3', text: '#1E7A52' },
+                            amber: { border: '#F0A500', bg: '#FFF8E8', text: '#7A5800' },
+                            red: { border: '#CC2200', bg: '#FFE8E8', text: '#8B0000' }
+                        }
+                    },
+                    boxShadow: {
+                        'soft': '0 4px 20px -2px rgba(0, 0, 0, 0.05)',
+                        'card': '0 2px 10px -2px rgba(0, 0, 0, 0.03)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            font-family: 'Manrope', sans-serif;
+            background-color: #FFFFFC;
+            color: #000000;
+            overflow-x: hidden;
+        }
+        ::-webkit-scrollbar { display: none; }
+        .hero-bg {
+            background: linear-gradient(135deg, rgba(255,255,252,1) 0%, rgba(245,245,242,0.5) 100%);
+        }
+    </style>
+</head>
+<body class="w-full min-h-screen m-0 p-0 text-brand-black antialiased flex flex-col">
+
+    <!-- STICKY NAV -->
+    <nav id="top-nav" class="sticky top-0 z-50 w-full h-16 bg-brand-porcelain/95 backdrop-blur-sm border-b border-brand-border flex items-center justify-between px-4 md:px-8 lg:px-12 transition-all duration-300">
+        <div class="flex items-center gap-3 cursor-pointer">
+            <div class="w-7 h-7 bg-brand-black rounded-lg flex items-center justify-center">
+                <span class="text-brand-magenta font-extrabold text-lg leading-none">R</span>
+            </div>
+            <span class="font-extrabold text-[20px] text-brand-black tracking-tight hidden sm:block">RUCompliant</span>
+        </div>
+
+        <div class="flex items-center gap-2 sm:gap-4">
+            <button class="px-3 sm:px-4 py-2 h-[44px] text-brand-magenta font-bold text-sm bg-white border-[1.5px] border-brand-magenta rounded-lg hover:bg-brand-magenta/5 transition-colors hidden sm:block">
+                Sign in
+            </button>
+            <button class="px-4 sm:px-5 py-2 h-[44px] bg-brand-magenta text-white font-bold text-sm rounded-lg hover:bg-brand-magentahover transition-colors shadow-sm w-full sm:w-auto">
+                Get started free
+            </button>
+        </div>
+    </nav>
+
+    <main class="flex-grow w-full">
+        <!-- HERO SECTION -->
+        <section id="hero-section" class="relative w-full min-h-[90vh] lg:min-h-[85vh] flex items-center justify-center pt-10 pb-20 px-4 md:px-8 hero-bg overflow-hidden">
+            <div class="max-w-7xl mx-auto w-full flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-8 relative z-10">
+
+                <!-- Hero Content -->
+                <div class="w-full lg:w-[620px] flex flex-col items-center lg:items-start text-center lg:text-left z-20">
+                    <h1 class="font-extrabold text-[40px] md:text-[50px] lg:text-[60px] text-brand-black leading-[1.1] tracking-[-1.5px] mb-6">
+                        Are you compliant?
+                    </h1>
+                    <p class="font-normal text-[18px] md:text-[20px] text-[#555555] leading-[1.6] max-w-[560px] mb-10">
+                        RUCompliant walks every UK microbusiness through exactly what they need to do — in plain English, in the right order, before deadlines hit.
+                    </p>
+
+                    <div class="w-full max-w-[480px] flex flex-col sm:flex-row gap-3 mb-6">
+                        <input type="email" placeholder="hello@yourbusiness.co.uk" class="flex-1 h-[44px] px-4 rounded-lg border border-brand-border bg-white text-[15px] focus:outline-none focus:ring-2 focus:ring-brand-magenta placeholder-brand-muted shadow-sm">
+                        <button class="h-[44px] px-6 bg-brand-magenta text-white font-bold text-[15px] rounded-lg hover:bg-brand-magentahover transition-colors shadow-sm whitespace-nowrap">
+                            Get started free
+                        </button>
+                    </div>
+
+                    <div class="flex flex-wrap justify-center lg:justify-start gap-x-4 gap-y-2 text-[12px] font-medium text-brand-muted">
+                        <span class="flex items-center gap-1"><i class="fa-solid fa-check text-brand-emerald"></i> Free for 14 days</span>
+                        <span class="hidden sm:inline">·</span>
+                        <span class="flex items-center gap-1"><i class="fa-solid fa-check text-brand-emerald"></i> No credit card</span>
+                        <span class="hidden sm:inline">·</span>
+                        <span class="flex items-center gap-1"><i class="fa-solid fa-check text-brand-emerald"></i> Cancel anytime</span>
+                    </div>
+                </div>
+
+                <!-- Hero Graphic (Desktop only) -->
+                <div class="hidden lg:flex w-full lg:w-1/2 justify-center lg:justify-end relative z-10">
+                    <!-- Floating Health Score Card -->
+                    <div class="w-[320px] bg-white rounded-[12px] border-[1.5px] border-brand-emerald p-6 shadow-soft animate-[bounce_4s_ease-in-out_infinite] transform translate-y-[-20px]">
+                        <div class="flex items-center justify-between mb-4">
+                            <span class="text-[11px] font-bold text-brand-muted uppercase tracking-[0.8px]">Compliance Health</span>
+                            <div class="w-8 h-8 rounded-full bg-rag-green-bg flex items-center justify-center">
+                                <i class="fa-solid fa-shield-check text-rag-green-text"></i>
+                            </div>
+                        </div>
+                        <div class="flex items-end gap-3 mb-2">
+                            <span class="font-extrabold text-[64px] leading-none text-brand-emerald tracking-tight">94</span>
+                            <span class="text-[14px] font-medium text-brand-muted mb-2">/ 100</span>
+                        </div>
+                        <div class="inline-flex items-center px-3 py-1.5 rounded-full bg-rag-green-bg text-rag-green-text text-[10px] font-bold uppercase tracking-wider mt-2">
+                            <i class="fa-solid fa-circle-check mr-1.5"></i> ALL CLEAR — YOU ARE COMPLIANT
+                        </div>
+
+                        <div class="mt-6 space-y-3">
+                            <div class="flex justify-between items-center text-sm">
+                                <span class="text-brand-muted">HMRC Self Assessment</span>
+                                <span class="text-brand-emerald font-semibold"><i class="fa-solid fa-check mr-1"></i> Done</span>
+                            </div>
+                            <div class="w-full h-1.5 bg-brand-surface rounded-full overflow-hidden">
+                                <div class="w-full h-full bg-brand-emerald rounded-full"></div>
+                            </div>
+
+                            <div class="flex justify-between items-center text-sm mt-4">
+                                <span class="text-brand-muted">Companies House</span>
+                                <span class="text-brand-emerald font-semibold"><i class="fa-solid fa-check mr-1"></i> Done</span>
+                            </div>
+                            <div class="w-full h-1.5 bg-brand-surface rounded-full overflow-hidden">
+                                <div class="w-full h-full bg-brand-emerald rounded-full"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Decorative blur behind card -->
+                    <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-brand-magenta/10 rounded-full blur-3xl -z-10"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- TRUST STRIP -->
+        <section id="trust-strip" class="w-full bg-brand-surface py-12 px-4 border-y border-brand-border">
+            <div class="max-w-5xl mx-auto flex flex-col md:flex-row justify-center items-center divide-y md:divide-y-0 md:divide-x divide-brand-border gap-8 md:gap-0">
+
+                <div class="w-full md:w-1/3 flex flex-col items-center justify-center py-4 md:py-0 px-4 text-center">
+                    <span class="font-extrabold text-[40px] text-brand-magenta leading-none mb-2">5.4M</span>
+                    <span class="font-medium text-[12px] text-brand-muted uppercase tracking-[0.5px]">UK businesses</span>
+                </div>
+
+                <div class="w-full md:w-1/3 flex flex-col items-center justify-center py-4 md:py-0 px-4 text-center">
+                    <span class="font-extrabold text-[40px] text-brand-magenta leading-none mb-2">100%</span>
+                    <span class="font-medium text-[12px] text-brand-muted uppercase tracking-[0.5px]">Plain English — no jargon</span>
+                </div>
+
+                <div class="w-full md:w-1/3 flex flex-col items-center justify-center py-4 md:py-0 px-4 text-center">
+                    <span class="font-extrabold text-[40px] text-brand-magenta leading-none mb-2">£200+</span>
+                    <span class="font-medium text-[12px] text-brand-muted uppercase tracking-[0.5px]">saved on average</span>
+                </div>
+
+            </div>
+        </section>
+
+        <!-- PROBLEM SECTION -->
+        <section id="problem-section" class="w-full bg-brand-porcelain py-24 px-4">
+            <div class="max-w-6xl mx-auto flex flex-col items-center">
+                <div class="text-center max-w-2xl mx-auto mb-16">
+                    <h2 class="font-extrabold text-[32px] md:text-[40px] text-brand-black leading-[1.2] tracking-tight mb-4">
+                        Nobody told you about this.
+                    </h2>
+                    <p class="font-normal text-[16px] text-brand-muted leading-[1.6]">
+                        Most microbusinesses are not non-compliant by choice. They just do not know what they do not know.
+                    </p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+                    <!-- Card 1 -->
+                    <div class="bg-brand-surface rounded-[12px] p-6 border border-brand-border shadow-card hover:shadow-soft transition-shadow">
+                        <div class="w-12 h-12 rounded-lg bg-brand-magenta/10 flex items-center justify-center mb-6">
+                            <i class="fa-solid fa-file-invoice text-[24px] text-brand-magenta"></i>
+                        </div>
+                        <h3 class="font-bold text-[18px] text-brand-black mb-3">You do not know what you owe</h3>
+                        <p class="font-normal text-[14px] text-brand-muted leading-[1.6]">
+                            Tax rules change constantly. It's impossible to keep track of exactly what you need to pay and when without an expert.
+                        </p>
+                    </div>
+
+                    <!-- Card 2 -->
+                    <div class="bg-brand-surface rounded-[12px] p-6 border border-brand-border shadow-card hover:shadow-soft transition-shadow">
+                        <div class="w-12 h-12 rounded-lg bg-brand-magenta/10 flex items-center justify-center mb-6">
+                            <i class="fa-solid fa-calendar-xmark text-[24px] text-brand-magenta"></i>
+                        </div>
+                        <h3 class="font-bold text-[18px] text-brand-black mb-3">Deadlines you have never heard of</h3>
+                        <p class="font-normal text-[14px] text-brand-muted leading-[1.6]">
+                            Confirmation statements, VAT quarters, PAYE deadlines. Missing just one can trigger immediate automatic fines.
+                        </p>
+                    </div>
+
+                    <!-- Card 3 -->
+                    <div class="bg-brand-surface rounded-[12px] p-6 border border-brand-border shadow-card hover:shadow-soft transition-shadow">
+                        <div class="w-12 h-12 rounded-lg bg-brand-magenta/10 flex items-center justify-center mb-6">
+                            <i class="fa-solid fa-triangle-exclamation text-[24px] text-brand-magenta"></i>
+                        </div>
+                        <h3 class="font-bold text-[18px] text-brand-black mb-3">Penalties that arrive without warning</h3>
+                        <p class="font-normal text-[14px] text-brand-muted leading-[1.6]">
+                            HMRC doesn't send friendly reminders. They send brown envelopes with late filing penalties that compound daily.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- HOW IT WORKS SECTION -->
+        <section id="how-it-works" class="w-full bg-white py-24 px-4 border-y border-brand-border">
+            <div class="max-w-[560px] mx-auto flex flex-col items-center">
+                <h2 class="font-extrabold text-[32px] md:text-[40px] text-brand-black leading-[1.2] tracking-tight mb-16 text-center">
+                    Sorted in 3 steps.
+                </h2>
+
+                <div class="w-full flex flex-col gap-8">
+                    <!-- Step 1 -->
+                    <div class="flex gap-6 items-start pb-8 border-b border-brand-border">
+                        <span class="font-extrabold text-[48px] md:text-[64px] text-brand-magenta leading-none mt-[-8px]">1</span>
+                        <div>
+                            <h3 class="font-bold text-[18px] text-brand-black mb-2">Answer 5 quick questions about your business.</h3>
+                            <p class="font-normal text-[15px] text-brand-muted leading-[1.6]">Tell us how you operate, and we'll figure out exactly which regulations apply to you. No legal jargon, just plain English.</p>
+                        </div>
+                    </div>
+
+                    <!-- Step 2 -->
+                    <div class="flex gap-6 items-start pb-8 border-b border-brand-border">
+                        <span class="font-extrabold text-[48px] md:text-[64px] text-brand-magenta leading-none mt-[-8px]">2</span>
+                        <div>
+                            <h3 class="font-bold text-[18px] text-brand-black mb-2">Get your personalised compliance picture instantly.</h3>
+                            <p class="font-normal text-[15px] text-brand-muted leading-[1.6]">See your overall Health Score and a clear, prioritised list of exactly what you need to do to get fully compliant today.</p>
+                        </div>
+                    </div>
+
+                    <!-- Step 3 -->
+                    <div class="flex gap-6 items-start">
+                        <span class="font-extrabold text-[48px] md:text-[64px] text-brand-magenta leading-none mt-[-8px]">3</span>
+                        <div>
+                            <h3 class="font-bold text-[18px] text-brand-black mb-2">We remind you before anything goes wrong — automatically.</h3>
+                            <p class="font-normal text-[15px] text-brand-muted leading-[1.6]">Never miss a deadline again. We'll send you simple, actionable alerts weeks before anything is due, keeping you in the green.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- PRICING SECTION -->
+        <section id="pricing" class="w-full bg-brand-porcelain py-24 px-4">
+            <div class="max-w-4xl mx-auto flex flex-col items-center">
+                <div class="text-center mb-16">
+                    <h2 class="font-extrabold text-[32px] md:text-[40px] text-brand-black leading-[1.2] tracking-tight mb-4">
+                        Simple, transparent pricing.
+                    </h2>
+                    <p class="font-normal text-[16px] text-brand-muted">One plan, everything included. Pay monthly or save with annual.</p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-[960px]">
+                    <!-- Monthly Card -->
+                    <div class="bg-white rounded-[12px] border border-brand-border p-8 flex flex-col h-full shadow-sm hover:shadow-md transition-shadow">
+                        <div class="mb-6">
+                            <h3 class="font-bold text-[20px] text-brand-black mb-2">Monthly</h3>
+                            <div class="flex items-baseline gap-1">
+                                <span class="font-extrabold text-[40px] text-brand-black">£49.99</span>
+                                <span class="font-medium text-[16px] text-brand-muted">/month</span>
+                            </div>
+                            <span class="text-[12px] font-medium text-brand-muted mt-1 block">Cancel anytime</span>
+                        </div>
+
+                        <div class="flex-grow">
+                            <ul class="space-y-4 mb-8">
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Full compliance health check</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Automated deadline reminders</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Plain English guidance</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Document storage vault</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">AI Compliance Advisor</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Email & chat support</span>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <button class="w-full h-[44px] bg-white border-[1.5px] border-brand-magenta text-brand-magenta font-bold text-[15px] rounded-lg hover:bg-brand-magenta/5 transition-colors">
+                            Start 14-day free trial
+                        </button>
+                    </div>
+
+                    <!-- Annual Card -->
+                    <div class="bg-white rounded-[12px] border-[2px] border-brand-magenta p-8 flex flex-col h-full relative shadow-soft transform md:-translate-y-2">
+                        <div class="absolute -top-4 right-6 bg-brand-magenta text-white text-[11px] font-bold uppercase tracking-wider py-1.5 px-3 rounded-full shadow-sm">
+                            Most popular
+                        </div>
+
+                        <div class="mb-6">
+                            <h3 class="font-bold text-[20px] text-brand-black mb-2">Annual</h3>
+                            <div class="flex items-baseline gap-1">
+                                <span class="font-extrabold text-[40px] text-brand-black">£499.99</span>
+                                <span class="font-medium text-[16px] text-brand-muted">/year</span>
+                            </div>
+                            <span class="text-[14px] font-semibold text-brand-emerald mt-1 block">2 months free</span>
+                        </div>
+
+                        <div class="flex-grow">
+                            <ul class="space-y-4 mb-8">
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black font-medium">Everything in Monthly, plus:</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Priority onboarding support</span>
+                                </li>
+                                <li class="flex items-start gap-3">
+                                    <i class="fa-solid fa-circle-check text-brand-emerald mt-1 text-[14px]"></i>
+                                    <span class="text-[14px] text-brand-black">Annual compliance review call</span>
+                                </li>
+                                <li class="flex items-start gap-3 opacity-0"><span class="text-[14px]">&nbsp;</span></li>
+                                <li class="flex items-start gap-3 opacity-0"><span class="text-[14px]">&nbsp;</span></li>
+                                <li class="flex items-start gap-3 opacity-0"><span class="text-[14px]">&nbsp;</span></li>
+                            </ul>
+                        </div>
+
+                        <button class="w-full h-[44px] bg-brand-magenta text-white font-bold text-[15px] rounded-lg hover:bg-brand-magentahover transition-colors shadow-sm">
+                            Start 14-day free trial
+                        </button>
+                    </div>
+                </div>
+
+                <div class="mt-8 text-center">
+                    <span class="text-[13px] font-medium text-brand-muted">14-day free trial · No credit card required</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- FINAL CTA BAND -->
+        <section id="final-cta" class="w-full bg-brand-black py-20 px-4">
+            <div class="max-w-3xl mx-auto flex flex-col items-center text-center">
+                <h2 class="font-extrabold text-[40px] md:text-[48px] text-white leading-[1.1] tracking-tight mb-4">
+                    Ready to find out?
+                </h2>
+                <p class="font-normal text-[16px] text-[#888888] mb-10">
+                    Takes 2 minutes. No credit card.
+                </p>
+
+                <div class="w-full max-w-[480px] flex flex-col sm:flex-row gap-3">
+                    <input type="email" placeholder="hello@yourbusiness.co.uk" class="flex-1 h-[44px] px-4 rounded-lg border-none bg-brand-porcelain text-[15px] text-brand-black focus:outline-none focus:ring-2 focus:ring-brand-magenta placeholder-brand-muted">
+                    <button class="h-[44px] px-6 bg-brand-magenta text-white font-bold text-[15px] rounded-lg hover:bg-brand-magentahover transition-colors whitespace-nowrap">
+                        Get started free
+                    </button>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- FOOTER -->
+    <footer id="footer" class="w-full bg-brand-porcelain py-10 px-4 border-t border-brand-border">
+        <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6 mb-8">
+            <div class="flex items-center gap-3">
+                <div class="w-6 h-6 bg-brand-black rounded-md flex items-center justify-center">
+                    <span class="text-brand-magenta font-extrabold text-sm leading-none">R</span>
+                </div>
+                <span class="font-medium text-[13px] text-brand-muted">Compliance That Has Your Back</span>
+            </div>
+
+            <div class="flex items-center gap-6 text-[13px] font-medium text-brand-muted">
+                <a href="#" class="hover:text-brand-magenta transition-colors">Privacy Policy</a>
+                <a href="#" class="hover:text-brand-magenta transition-colors">Terms</a>
+                <a href="#" class="hover:text-brand-magenta transition-colors">Contact</a>
+            </div>
+        </div>
+
+        <div class="text-center">
+            <p class="text-[12px] font-medium text-brand-muted">&copy; 2026 RUCompliant Ltd</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/docs/ux-reference/onboarding-signup.html
+++ b/docs/ux-reference/onboarding-signup.html
@@ -1,0 +1,4 @@
+<!-- UX Reference: Sign Up / Magic Link screen -->
+<!-- Source: UX Pilot export, saved 2026-03-30 -->
+<!-- Covers: Email signup form + "Check your email" confirmation state -->
+<!-- To view: open this file directly in a browser -->

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Landing Page', () => {
   test('displays the hero content', async ({ page }) => {
     await page.goto('/')
-    await expect(page.getByText('Compliance That Has Your Back')).toBeVisible()
-    await expect(page.getByText('Get Started')).toBeVisible()
+    await expect(page.getByText('Are you compliant?')).toBeVisible()
+    await expect(page.getByText('Get started free', { exact: false })).toBeVisible()
   })
 
   test('has correct page title', async ({ page }) => {
@@ -15,6 +15,17 @@ test.describe('Landing Page', () => {
   test('is responsive on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 })
     await page.goto('/')
-    await expect(page.getByText('Compliance That Has Your Back')).toBeVisible()
+    await expect(page.getByText('Are you compliant?')).toBeVisible()
+  })
+
+  test('displays pricing section', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('£49.99')).toBeVisible()
+    await expect(page.getByText('£499.99')).toBeVisible()
+  })
+
+  test('displays navigation with sign in and get started', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('RUCompliant')).toBeVisible()
   })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,11 +5,11 @@ import App from './App'
 describe('App', () => {
   it('renders the landing page headline', () => {
     render(<App />)
-    expect(screen.getByText('Compliance That Has Your Back')).toBeInTheDocument()
+    expect(screen.getByText('Are you compliant?')).toBeInTheDocument()
   })
 
   it('renders the get started CTA', () => {
     render(<App />)
-    expect(screen.getByText('Get Started')).toBeInTheDocument()
+    expect(screen.getAllByText(/Get started free/i).length).toBeGreaterThan(0)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,11 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {/* Public routes */}
+        {/* Landing page — full width, own nav */}
+        <Route path="/" element={<LandingPage />} />
+
+        {/* Public routes with centered layout */}
         <Route element={<PublicLayout />}>
-          <Route path="/" element={<LandingPage />} />
           <Route path="/auth" element={<AuthPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
           <Route path="/onboarding" element={<OnboardingPage />} />

--- a/src/components/landing/EmailSignup.tsx
+++ b/src/components/landing/EmailSignup.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+interface EmailSignupProps {
+  variant?: "light" | "dark";
+  className?: string;
+}
+
+export default function EmailSignup({ variant = "light", className }: EmailSignupProps) {
+  const [email, setEmail] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate(`/auth?email=${encodeURIComponent(email)}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={cn("w-full max-w-[480px]", className)}>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="hello@yourbusiness.co.uk"
+          required
+          className={cn(
+            "flex-1 h-[44px] px-4 rounded-lg text-[15px] focus:outline-none focus:ring-2 focus:ring-primary transition-all",
+            variant === "light"
+              ? "border border-border bg-white text-foreground placeholder-muted-foreground"
+              : "border-none bg-page text-foreground placeholder-muted-foreground"
+          )}
+        />
+        <button
+          type="submit"
+          className="h-[44px] px-6 bg-magenta text-white font-bold text-[15px] rounded-lg hover:bg-magenta-600 transition-colors whitespace-nowrap"
+        >
+          Get started free
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/landing/FeatureCard.tsx
+++ b/src/components/landing/FeatureCard.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+import AppIcon from "@/components/ui/AppIcon";
+import type { IconKey } from "@/components/ui/AppIcon";
+
+interface FeatureCardProps {
+  icon: IconKey;
+  title: string;
+  description: string;
+  className?: string;
+}
+
+export default function FeatureCard({ icon, title, description, className }: FeatureCardProps) {
+  return (
+    <div className={cn(
+      "bg-surface rounded-xl p-6 border border-border transition-all",
+      className
+    )}>
+      <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center mb-6">
+        <AppIcon name={icon} className="w-6 h-6 text-primary" />
+      </div>
+      <h3 className="font-bold text-lg text-foreground mb-3">{title}</h3>
+      <p className="font-normal text-sm text-muted-foreground leading-relaxed">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/src/components/landing/HeroHealthCard.tsx
+++ b/src/components/landing/HeroHealthCard.tsx
@@ -1,0 +1,55 @@
+import AppIcon from "@/components/ui/AppIcon";
+
+export default function HeroHealthCard() {
+  return (
+    <div className="hidden lg:flex w-full lg:w-1/2 justify-center lg:justify-end relative z-10">
+      <div className="w-[320px] bg-white rounded-xl border-[1.5px] border-emerald p-6 animate-bounce-slow">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <span className="section-label text-muted-foreground">Compliance Health</span>
+          <div className="w-8 h-8 rounded-full bg-emerald-50 flex items-center justify-center">
+            <AppIcon name="shield-check" className="w-4 h-4 text-emerald" />
+          </div>
+        </div>
+
+        {/* Score */}
+        <div className="flex items-end gap-3 mb-2">
+          <span className="font-extrabold text-[64px] leading-none text-emerald tracking-tight">94</span>
+          <span className="text-sm font-medium text-muted-foreground mb-2">/ 100</span>
+        </div>
+
+        {/* Status badge */}
+        <div className="inline-flex items-center px-3 py-1.5 rounded-full bg-emerald-50 text-emerald-700 text-[10px] font-bold uppercase tracking-wider mt-2">
+          <AppIcon name="circle-check" className="w-3 h-3 mr-1.5" />
+          ALL CLEAR — YOU ARE COMPLIANT
+        </div>
+
+        {/* Progress items */}
+        <div className="mt-6 space-y-3">
+          <div className="flex justify-between items-center text-sm">
+            <span className="text-muted-foreground">HMRC Self Assessment</span>
+            <span className="text-emerald font-semibold flex items-center gap-1">
+              <AppIcon name="check" className="w-3 h-3" /> Done
+            </span>
+          </div>
+          <div className="w-full h-1.5 bg-surface rounded-full overflow-hidden">
+            <div className="w-full h-full bg-emerald rounded-full" />
+          </div>
+
+          <div className="flex justify-between items-center text-sm mt-4">
+            <span className="text-muted-foreground">Companies House</span>
+            <span className="text-emerald font-semibold flex items-center gap-1">
+              <AppIcon name="check" className="w-3 h-3" /> Done
+            </span>
+          </div>
+          <div className="w-full h-1.5 bg-surface rounded-full overflow-hidden">
+            <div className="w-full h-full bg-emerald rounded-full" />
+          </div>
+        </div>
+      </div>
+
+      {/* Decorative blur */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-primary/10 rounded-full blur-3xl -z-10" />
+    </div>
+  );
+}

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+
+export default function LandingFooter() {
+  return (
+    <footer className="w-full bg-page py-10 px-4 border-t border-border">
+      <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6 mb-8">
+        <div className="flex items-center gap-3">
+          <div className="w-6 h-6 bg-black rounded-md flex items-center justify-center">
+            <span className="text-primary font-extrabold text-sm leading-none">R</span>
+          </div>
+          <span className="font-medium text-[13px] text-muted-foreground">
+            Compliance That Has Your Back
+          </span>
+        </div>
+
+        <div className="flex items-center gap-6 text-[13px] font-medium text-muted-foreground">
+          <Link to="#" className="hover:text-primary transition-colors">Privacy Policy</Link>
+          <Link to="#" className="hover:text-primary transition-colors">Terms</Link>
+          <Link to="#" className="hover:text-primary transition-colors">Contact</Link>
+        </div>
+      </div>
+
+      <div className="text-center">
+        <p className="text-xs font-medium text-muted-foreground">
+          &copy; {new Date().getFullYear()} RUCompliant Ltd
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/LandingNav.tsx
+++ b/src/components/landing/LandingNav.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+
+export default function LandingNav() {
+  return (
+    <nav className="sticky top-0 z-50 w-full h-16 bg-page/95 backdrop-blur-sm border-b border-border flex items-center justify-between px-4 md:px-8 lg:px-12 transition-all duration-300">
+      <div className="flex items-center gap-3 cursor-pointer">
+        <div className="w-7 h-7 bg-black rounded-lg flex items-center justify-center">
+          <span className="text-primary font-extrabold text-lg leading-none">R</span>
+        </div>
+        <span className="font-extrabold text-xl text-foreground tracking-tight hidden sm:block">
+          RUCompliant
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 sm:gap-4">
+        <Link to="/auth">
+          <button className="px-3 sm:px-4 py-2 h-[44px] text-primary font-bold text-sm bg-white border-[1.5px] border-primary rounded-lg hover:bg-primary/5 transition-colors hidden sm:block">
+            Sign in
+          </button>
+        </Link>
+        <Link to="/auth">
+          <button className="px-4 sm:px-5 py-2 h-[44px] bg-magenta text-white font-bold text-sm rounded-lg hover:bg-magenta-600 transition-colors w-full sm:w-auto">
+            Get started free
+          </button>
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/landing/NumberedStep.tsx
+++ b/src/components/landing/NumberedStep.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface NumberedStepProps {
+  number: number;
+  title: string;
+  description: string;
+  isLast?: boolean;
+  className?: string;
+}
+
+export default function NumberedStep({ number, title, description, isLast = false, className }: NumberedStepProps) {
+  return (
+    <div className={cn(
+      "flex gap-6 items-start",
+      !isLast && "pb-8 border-b border-border",
+      className
+    )}>
+      <span className="font-extrabold text-[48px] md:text-[64px] text-primary leading-none mt-[-8px] select-none">
+        {number}
+      </span>
+      <div>
+        <h3 className="font-bold text-lg text-foreground mb-2">{title}</h3>
+        <p className="font-normal text-[15px] text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/PricingCard.tsx
+++ b/src/components/landing/PricingCard.tsx
@@ -1,0 +1,86 @@
+import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import AppIcon from "@/components/ui/AppIcon";
+
+interface PricingFeature {
+  text: string;
+  bold?: boolean;
+}
+
+interface PricingCardProps {
+  name: string;
+  price: string;
+  period: string;
+  subtitle: string;
+  features: PricingFeature[];
+  highlighted?: boolean;
+  badge?: string;
+  ctaText?: string;
+  className?: string;
+}
+
+export default function PricingCard({
+  name,
+  price,
+  period,
+  subtitle,
+  features,
+  highlighted = false,
+  badge,
+  ctaText = "Start 14-day free trial",
+  className,
+}: PricingCardProps) {
+  return (
+    <div className={cn(
+      "bg-white rounded-xl p-8 flex flex-col h-full relative",
+      highlighted
+        ? "border-2 border-primary md:-translate-y-2"
+        : "border border-border",
+      className
+    )}>
+      {badge && (
+        <div className="absolute -top-4 right-6 bg-primary text-white text-[11px] font-bold uppercase tracking-wider py-1.5 px-3 rounded-full">
+          {badge}
+        </div>
+      )}
+
+      <div className="mb-6">
+        <h3 className="font-bold text-xl text-foreground mb-2">{name}</h3>
+        <div className="flex items-baseline gap-1">
+          <span className="font-extrabold text-[40px] text-foreground">{price}</span>
+          <span className="font-medium text-base text-muted-foreground">{period}</span>
+        </div>
+        <span className={cn(
+          "text-sm font-medium mt-1 block",
+          highlighted ? "text-emerald font-semibold" : "text-muted-foreground text-xs"
+        )}>
+          {subtitle}
+        </span>
+      </div>
+
+      <div className="flex-grow">
+        <ul className="space-y-4 mb-8">
+          {features.map((feature, i) => (
+            <li key={i} className="flex items-start gap-3">
+              <AppIcon name="circle-check" className="w-4 h-4 text-emerald mt-0.5 shrink-0" />
+              <span className={cn("text-sm text-foreground", feature.bold && "font-medium")}>
+                {feature.text}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Link to="/auth">
+        <button className={cn(
+          "w-full h-[44px] font-bold text-[15px] rounded-lg transition-colors",
+          highlighted
+            ? "bg-magenta text-white hover:bg-magenta-600"
+            : "bg-white border-[1.5px] border-primary text-primary hover:bg-primary/5"
+        )}>
+          {ctaText}
+        </button>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/landing/SectionHeader.tsx
+++ b/src/components/landing/SectionHeader.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface SectionHeaderProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+}
+
+export default function SectionHeader({ title, subtitle, className }: SectionHeaderProps) {
+  return (
+    <div className={cn("text-center max-w-2xl mx-auto", className)}>
+      <h2 className="font-extrabold text-[32px] md:text-[40px] text-foreground leading-[1.2] tracking-tight mb-4">
+        {title}
+      </h2>
+      {subtitle && (
+        <p className="font-normal text-base text-muted-foreground leading-relaxed">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/landing/StatStrip.tsx
+++ b/src/components/landing/StatStrip.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+interface StatItem {
+  value: string;
+  label: string;
+}
+
+interface StatStripProps {
+  stats: StatItem[];
+  className?: string;
+}
+
+export default function StatStrip({ stats, className }: StatStripProps) {
+  return (
+    <div className={cn(
+      "w-full bg-surface py-12 px-4 border-y border-border",
+      className
+    )}>
+      <div className="max-w-5xl mx-auto flex flex-col md:flex-row justify-center items-center divide-y md:divide-y-0 md:divide-x divide-border gap-8 md:gap-0">
+        {stats.map((stat, i) => (
+          <div
+            key={i}
+            className="w-full md:w-1/3 flex flex-col items-center justify-center py-4 md:py-0 px-4 text-center"
+          >
+            <span className="font-extrabold text-[40px] text-primary leading-none mb-2">
+              {stat.value}
+            </span>
+            <span className="section-label text-muted-foreground">
+              {stat.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/TrustBadges.tsx
+++ b/src/components/landing/TrustBadges.tsx
@@ -1,0 +1,19 @@
+import AppIcon from "@/components/ui/AppIcon";
+
+export default function TrustBadges() {
+  return (
+    <div className="flex flex-wrap justify-center lg:justify-start gap-x-4 gap-y-2 text-xs font-medium text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <AppIcon name="check" className="w-3 h-3 text-emerald" /> Free for 14 days
+      </span>
+      <span className="hidden sm:inline">&middot;</span>
+      <span className="flex items-center gap-1">
+        <AppIcon name="check" className="w-3 h-3 text-emerald" /> No credit card
+      </span>
+      <span className="hidden sm:inline">&middot;</span>
+      <span className="flex items-center gap-1">
+        <AppIcon name="check" className="w-3 h-3 text-emerald" /> Cancel anytime
+      </span>
+    </div>
+  );
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,19 +1,190 @@
-import { Link } from 'react-router-dom'
-import { Button } from '@/components/ui'
+import LandingNav from "@/components/landing/LandingNav";
+import HeroHealthCard from "@/components/landing/HeroHealthCard";
+import EmailSignup from "@/components/landing/EmailSignup";
+import TrustBadges from "@/components/landing/TrustBadges";
+import StatStrip from "@/components/landing/StatStrip";
+import SectionHeader from "@/components/landing/SectionHeader";
+import FeatureCard from "@/components/landing/FeatureCard";
+import NumberedStep from "@/components/landing/NumberedStep";
+import PricingCard from "@/components/landing/PricingCard";
+import LandingFooter from "@/components/landing/LandingFooter";
+
+const TRUST_STATS = [
+  { value: "5.4M", label: "UK businesses" },
+  { value: "100%", label: "Plain English — no jargon" },
+  { value: "£200+", label: "saved on average" },
+];
+
+const PROBLEM_CARDS = [
+  {
+    icon: "file-text" as const,
+    title: "You don't know what you owe",
+    description: "Tax rules change constantly. It's impossible to keep track of exactly what you need to pay and when without an expert.",
+  },
+  {
+    icon: "calendar-x" as const,
+    title: "Deadlines you've never heard of",
+    description: "Confirmation statements, VAT quarters, PAYE deadlines. Missing just one can trigger immediate automatic fines.",
+  },
+  {
+    icon: "alert-triangle" as const,
+    title: "Penalties that arrive without warning",
+    description: "HMRC doesn't send friendly reminders. They send brown envelopes with late filing penalties that compound daily.",
+  },
+];
+
+const HOW_IT_WORKS_STEPS = [
+  {
+    title: "Answer 5 quick questions about your business.",
+    description: "Tell us how you operate, and we'll figure out exactly which regulations apply to you. No legal jargon, just plain English.",
+  },
+  {
+    title: "Get your personalised compliance picture instantly.",
+    description: "See your overall Health Score and a clear, prioritised list of exactly what you need to do to get fully compliant today.",
+  },
+  {
+    title: "We remind you before anything goes wrong — automatically.",
+    description: "Never miss a deadline again. We'll send you simple, actionable alerts weeks before anything is due, keeping you in the green.",
+  },
+];
+
+const MONTHLY_FEATURES = [
+  { text: "Full compliance health check" },
+  { text: "Automated deadline reminders" },
+  { text: "Plain English guidance" },
+  { text: "Document storage vault" },
+  { text: "AI Compliance Advisor" },
+  { text: "Email & chat support" },
+];
+
+const ANNUAL_FEATURES = [
+  { text: "Everything in Monthly, plus:", bold: true },
+  { text: "Priority onboarding support" },
+  { text: "Annual compliance review call" },
+];
 
 export default function LandingPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[80vh] text-center">
-      <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-4">
-        Compliance That Has Your Back
-      </h1>
-      <p className="text-lg text-muted-foreground max-w-xl mb-8">
-        The simple way for UK small businesses to stay compliant.
-        No jargon, no stress — just clear guidance and peace of mind.
-      </p>
-      <Link to="/auth">
-        <Button size="lg">Get Started</Button>
-      </Link>
+    <div className="flex flex-col min-h-screen bg-page">
+      {/* NAV */}
+      <LandingNav />
+
+      <main className="flex-grow w-full">
+        {/* HERO */}
+        <section className="relative w-full min-h-[90vh] lg:min-h-[85vh] flex items-center justify-center pt-10 pb-20 px-4 md:px-8 overflow-hidden">
+          <div className="max-w-7xl mx-auto w-full flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-8 relative z-10">
+            {/* Hero Content */}
+            <div className="w-full lg:w-[620px] flex flex-col items-center lg:items-start text-center lg:text-left z-20">
+              <h1 className="font-extrabold text-[40px] md:text-[50px] lg:text-[60px] text-foreground leading-[1.1] tracking-[-1.5px] mb-6">
+                Are you compliant?
+              </h1>
+              <p className="font-normal text-lg md:text-xl text-muted-foreground leading-relaxed max-w-[560px] mb-10">
+                RUCompliant walks every UK microbusiness through exactly what they need to do — in plain English, in the right order, before deadlines hit.
+              </p>
+
+              <EmailSignup variant="light" className="mb-6" />
+              <TrustBadges />
+            </div>
+
+            {/* Hero Graphic */}
+            <HeroHealthCard />
+          </div>
+        </section>
+
+        {/* TRUST STRIP */}
+        <StatStrip stats={TRUST_STATS} />
+
+        {/* PROBLEM SECTION */}
+        <section className="w-full bg-page py-24 px-4">
+          <div className="max-w-6xl mx-auto flex flex-col items-center">
+            <SectionHeader
+              title="Nobody told you about this."
+              subtitle="Most microbusinesses are not non-compliant by choice. They just don't know what they don't know."
+              className="mb-16"
+            />
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+              {PROBLEM_CARDS.map((card) => (
+                <FeatureCard key={card.title} {...card} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* HOW IT WORKS */}
+        <section className="w-full bg-white py-24 px-4 border-y border-border">
+          <div className="max-w-[560px] mx-auto flex flex-col items-center">
+            <h2 className="font-extrabold text-[32px] md:text-[40px] text-foreground leading-[1.2] tracking-tight mb-16 text-center">
+              Sorted in 3 steps.
+            </h2>
+
+            <div className="w-full flex flex-col gap-8">
+              {HOW_IT_WORKS_STEPS.map((step, i) => (
+                <NumberedStep
+                  key={i}
+                  number={i + 1}
+                  title={step.title}
+                  description={step.description}
+                  isLast={i === HOW_IT_WORKS_STEPS.length - 1}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* PRICING */}
+        <section className="w-full bg-page py-24 px-4">
+          <div className="max-w-4xl mx-auto flex flex-col items-center">
+            <SectionHeader
+              title="Simple, transparent pricing."
+              subtitle="One plan, everything included. Pay monthly or save with annual."
+              className="mb-16"
+            />
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-[960px]">
+              <PricingCard
+                name="Monthly"
+                price="£49.99"
+                period="/month"
+                subtitle="Cancel anytime"
+                features={MONTHLY_FEATURES}
+              />
+              <PricingCard
+                name="Annual"
+                price="£499.99"
+                period="/year"
+                subtitle="2 months free"
+                features={ANNUAL_FEATURES}
+                highlighted
+                badge="Most popular"
+              />
+            </div>
+
+            <div className="mt-8 text-center">
+              <span className="text-[13px] font-medium text-muted-foreground">
+                14-day free trial &middot; No credit card required
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* FINAL CTA */}
+        <section className="w-full bg-black py-20 px-4">
+          <div className="max-w-3xl mx-auto flex flex-col items-center text-center">
+            <h2 className="font-extrabold text-[40px] md:text-[48px] text-white leading-[1.1] tracking-tight mb-4">
+              Ready to find out?
+            </h2>
+            <p className="font-normal text-base text-muted-foreground mb-10">
+              Takes 2 minutes. No credit card.
+            </p>
+
+            <EmailSignup variant="dark" />
+          </div>
+        </section>
+      </main>
+
+      {/* FOOTER */}
+      <LandingFooter />
     </div>
-  )
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -214,7 +214,8 @@ export default {
   			'pulse-soft': 'pulse-soft 2s ease-in-out infinite',
   			'slide-up': 'slide-up 0.3s ease-out forwards',
   			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
+  			'accordion-up': 'accordion-up 0.2s ease-out',
+  			'bounce-slow': 'bounce 4s ease-in-out infinite'
   		},
   		transitionDuration: {
   			'250': '250ms',


### PR DESCRIPTION
## Summary

Full landing page built from UX design reference, componentised into 10 reusable pieces:

- **Hero** — "Are you compliant?" headline, email signup form, trust badges, floating health score card (desktop only)
- **Trust Strip** — 3 key stats (5.4M UK businesses, 100% plain English, £200+ saved)
- **Problem Section** — 3 feature cards explaining compliance pain points
- **How It Works** — 3 numbered steps
- **Pricing** — Monthly (£49.99) and Annual (£499.99, highlighted) cards with feature lists
- **Final CTA** — Black background band with email signup
- **Footer** — Logo, tagline, legal links, copyright

### Reusable Components Created
`SectionHeader`, `FeatureCard`, `EmailSignup`, `StatStrip`, `NumberedStep`, `PricingCard`, `TrustBadges`, `HeroHealthCard`, `LandingNav`, `LandingFooter`

### Other Changes
- Landing page now renders outside PublicLayout (full-width with own nav)
- Updated App.tsx routing
- Updated E2E tests and unit tests for new content
- UX reference HTML saved to `docs/ux-reference/`
- Added `bounce-slow` animation to Tailwind config

Closes #16

## Checks

- **Lint**: clean
- **Tests**: 38/38 pass
- **Build**: passes

## Test plan

- [ ] Visit http://localhost:5173/ — see full landing page
- [ ] Hero: headline, email input, "Get started free" button, trust badges
- [ ] Trust strip: 3 stats visible
- [ ] Problem cards: 3 cards with icons
- [ ] How It Works: 3 numbered steps
- [ ] Pricing: Monthly + Annual cards, "Most popular" badge on Annual
- [ ] Final CTA: black band with email signup
- [ ] Footer: logo, links, copyright
- [ ] Mobile (375px): responsive, no horizontal scroll
- [ ] "Get started free" navigates to /auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)