### PR TITLE
F-007: Auth service, enhanced store, and AuthProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Auth service with magic link sign-in, sign-out, session management, and onboarding check (F-007)
+- AuthProvider component wiring Supabase auth state to Zustand store
+- ProtectedRoute now redirects to /onboarding if onboarding not completed
 - Full landing page with 7 sections matching UX design (F-023): Hero, Trust Strip, Problem, How It Works, Pricing, Final CTA, Footer
 - 8 reusable landing components: LandingNav, HeroHealthCard, EmailSignup, TrustBadges, StatStrip, SectionHeader, FeatureCard, NumberedStep, PricingCard, LandingFooter
 - Landing page renders outside PublicLayout (full-width with own nav)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import AuthProvider from '@/components/auth/AuthProvider'
 import PublicLayout from '@/components/layout/PublicLayout'
 import AppLayout from '@/components/layout/AppLayout'
 import ProtectedRoute from '@/components/auth/ProtectedRoute'
@@ -14,6 +15,7 @@ import SettingsPage from '@/pages/SettingsPage'
 
 function App() {
   return (
+    <AuthProvider>
     <BrowserRouter>
       <Routes>
         {/* Landing page — full width, own nav */}
@@ -38,6 +40,7 @@ function App() {
         </Route>
       </Routes>
     </BrowserRouter>
+    </AuthProvider>
   )
 }
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuthStore } from '@/stores/authStore'
+import { checkOnboardingCompleted } from '@/services/authService'
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { setUser, setSession, setLoading, setOnboardingCompleted } = useAuthStore()
+
+  useEffect(() => {
+    // Get initial session
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+      setUser(session?.user ?? null)
+
+      if (session?.user) {
+        checkOnboardingCompleted(session.user.id).then(setOnboardingCompleted)
+      }
+
+      setLoading(false)
+    })
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (_event, session) => {
+        setSession(session)
+        setUser(session?.user ?? null)
+
+        if (session?.user) {
+          const completed = await checkOnboardingCompleted(session.user.id)
+          setOnboardingCompleted(completed)
+        } else {
+          setOnboardingCompleted(false)
+        }
+
+        setLoading(false)
+      }
+    )
+
+    return () => subscription.unsubscribe()
+  }, [setUser, setSession, setLoading, setOnboardingCompleted])
+
+  return <>{children}</>
+}

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { LoadingSpinner } from '@/components/ui'
 
 export default function ProtectedRoute() {
-  const { user, loading } = useAuthStore()
+  const { user, loading, onboardingCompleted } = useAuthStore()
 
   if (loading) {
     return (
@@ -17,7 +17,9 @@ export default function ProtectedRoute() {
     return <Navigate to="/auth" replace />
   }
 
-  // Future: check onboarding completion (F-009)
-  // For now, authenticated users go straight through
+  if (onboardingCompleted === false) {
+    return <Navigate to="/onboarding" replace />
+  }
+
   return <Outlet />
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,42 @@
+import { supabase } from '@/lib/supabase'
+
+const APP_URL = import.meta.env.VITE_APP_URL || 'http://localhost:5173'
+
+export async function signInWithMagicLink(email: string) {
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: {
+      emailRedirectTo: `${APP_URL}/auth/callback`,
+    },
+  })
+
+  if (error) throw error
+  return { success: true }
+}
+
+export async function signOut() {
+  const { error } = await supabase.auth.signOut()
+  if (error) throw error
+}
+
+export async function getSession() {
+  const { data: { session }, error } = await supabase.auth.getSession()
+  if (error) throw error
+  return session
+}
+
+export async function checkOnboardingCompleted(userId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('business_profiles')
+    .select('onboarding_completed')
+    .eq('user_id', userId)
+    .single()
+
+  if (error || !data) return false
+  return data.onboarding_completed
+}
+
+export function onAuthStateChange(callback: (event: string, session: unknown) => void) {
+  const { data: { subscription } } = supabase.auth.onAuthStateChange(callback)
+  return subscription
+}

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -7,6 +7,7 @@ describe('authStore', () => {
       user: null,
       session: null,
       loading: true,
+      onboardingCompleted: null,
     })
   })
 
@@ -15,6 +16,7 @@ describe('authStore', () => {
     expect(state.user).toBeNull()
     expect(state.session).toBeNull()
     expect(state.loading).toBe(true)
+    expect(state.onboardingCompleted).toBeNull()
   })
 
   it('sets loading state', () => {
@@ -33,5 +35,25 @@ describe('authStore', () => {
     useAuthStore.getState().setUser(mockUser)
     useAuthStore.getState().setUser(null)
     expect(useAuthStore.getState().user).toBeNull()
+  })
+
+  it('isAuthenticated returns true when user is set', () => {
+    const mockUser = { id: '123', email: 'sarah@example.com' } as never
+    useAuthStore.getState().setUser(mockUser)
+    expect(useAuthStore.getState().isAuthenticated()).toBe(true)
+  })
+
+  it('isAuthenticated returns false when no user', () => {
+    expect(useAuthStore.getState().isAuthenticated()).toBe(false)
+  })
+
+  it('sets onboarding completed', () => {
+    useAuthStore.getState().setOnboardingCompleted(true)
+    expect(useAuthStore.getState().onboardingCompleted).toBe(true)
+  })
+
+  it('sets onboarding to false', () => {
+    useAuthStore.getState().setOnboardingCompleted(false)
+    expect(useAuthStore.getState().onboardingCompleted).toBe(false)
   })
 })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,16 +5,22 @@ interface AuthState {
   user: User | null
   session: Session | null
   loading: boolean
+  onboardingCompleted: boolean | null
   setUser: (user: User | null) => void
   setSession: (session: Session | null) => void
   setLoading: (loading: boolean) => void
+  setOnboardingCompleted: (completed: boolean) => void
+  isAuthenticated: () => boolean
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   session: null,
   loading: true,
+  onboardingCompleted: null,
   setUser: (user) => set({ user }),
   setSession: (session) => set({ session }),
   setLoading: (loading) => set({ loading }),
+  setOnboardingCompleted: (completed) => set({ onboardingCompleted: completed }),
+  isAuthenticated: () => !!get().user,
 }))


### PR DESCRIPTION
## Summary
- `authService.ts`: `signInWithMagicLink()`, `signOut()`, `getSession()`, `checkOnboardingCompleted()`, `onAuthStateChange()`
- Enhanced `authStore`: `isAuthenticated()`, `onboardingCompleted` state, `setOnboardingCompleted()`
- `AuthProvider`: wires Supabase `onAuthStateChange` to Zustand store, checks onboarding status
- `ProtectedRoute`: now redirects to `/onboarding` if onboarding not completed
- `App.tsx`: wrapped with `AuthProvider`
- 8 auth store tests (4 new)

Closes #20

## Checks
- **Lint**: clean | **Tests**: 52/52 pass (4 new) | **Build**: passes

## Test plan
- [ ] Auth state initialises as loading, then resolves
- [ ] Unauthenticated users redirected to /auth from protected routes
- [ ] After magic link auth, store updates with user/session
- [ ] Onboarding check redirects new users to /onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)