### PR TITLE
F-008: Auth pages with signup, magic link, and callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Auth pages matching UX design: signup form, magic link sent confirmation, auth callback redirect (F-008)
+- MagicLinkSent component with resend functionality
+- AuthCallbackPage routes users to /onboarding or /app/dashboard based on onboarding status
 - Auth service with magic link sign-in, sign-out, session management, and onboarding check (F-007)
 - AuthProvider component wiring Supabase auth state to Zustand store
 - ProtectedRoute now redirects to /onboarding if onboarding not completed

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { supabase } from '@/lib/supabase'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useAuthStore } from '@/stores/authStore'
 import { checkOnboardingCompleted } from '@/services/authService'
 
@@ -7,6 +7,12 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const { setUser, setSession, setLoading, setOnboardingCompleted } = useAuthStore()
 
   useEffect(() => {
+    // Skip auth initialisation if Supabase isn't configured (e.g. CI, preview)
+    if (!isSupabaseConfigured) {
+      setLoading(false)
+      return
+    }
+
     // Get initial session
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session)
@@ -16,6 +22,8 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         checkOnboardingCompleted(session.user.id).then(setOnboardingCompleted)
       }
 
+      setLoading(false)
+    }).catch(() => {
       setLoading(false)
     })
 

--- a/src/components/auth/MagicLinkSent.tsx
+++ b/src/components/auth/MagicLinkSent.tsx
@@ -1,0 +1,32 @@
+import AppIcon from "@/components/ui/AppIcon";
+
+interface MagicLinkSentProps {
+  email: string;
+  onResend: () => void;
+}
+
+export default function MagicLinkSent({ email, onResend }: MagicLinkSentProps) {
+  return (
+    <div className="text-center py-4">
+      <div className="w-12 h-12 mx-auto mb-6 flex items-center justify-center">
+        <AppIcon name="mail" className="w-12 h-12 text-primary" />
+      </div>
+
+      <h2 className="font-extrabold text-[22px] text-foreground mb-3">
+        Check your email
+      </h2>
+
+      <p className="font-normal text-sm text-muted-foreground leading-relaxed mb-6 max-w-[280px] mx-auto">
+        We sent a magic link to <strong className="text-foreground">{email}</strong> — click it to sign in. It expires in 15 minutes.
+      </p>
+
+      <button
+        type="button"
+        onClick={onResend}
+        className="text-sm font-semibold text-primary hover:underline"
+      >
+        Resend the link
+      </button>
+    </div>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,12 +3,14 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+export const isSupabaseConfigured = !!(supabaseUrl && supabaseAnonKey)
+
 // Warn but don't crash — allows landing page to render without env vars (e.g. in CI)
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!isSupabaseConfigured) {
   console.warn('Missing Supabase environment variables. Auth and data features will not work.')
 }
 
 export const supabase = createClient(
-  supabaseUrl ?? 'https://placeholder.supabase.co',
-  supabaseAnonKey ?? 'placeholder-key'
+  supabaseUrl || 'https://placeholder.supabase.co',
+  supabaseAnonKey || 'placeholder-key'
 )

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,6 +1,28 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { LoadingSpinner } from '@/components/ui'
+import { useAuthStore } from '@/stores/authStore'
 
 export default function AuthCallbackPage() {
+  const navigate = useNavigate()
+  const { user, loading, onboardingCompleted } = useAuthStore()
+
+  useEffect(() => {
+    if (loading) return
+
+    if (!user) {
+      // Auth failed or expired — send back to auth page
+      navigate('/auth', { replace: true })
+      return
+    }
+
+    if (onboardingCompleted) {
+      navigate('/app/dashboard', { replace: true })
+    } else {
+      navigate('/onboarding', { replace: true })
+    }
+  }, [user, loading, onboardingCompleted, navigate])
+
   return (
     <div className="flex flex-col items-center justify-center min-h-[80vh]">
       <LoadingSpinner size="lg" message="Verifying your link..." centered />

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,33 +1,138 @@
-import { Card, AppIcon, Button } from '@/components/ui'
+import { useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import AppIcon from "@/components/ui/AppIcon";
+import MagicLinkSent from "@/components/auth/MagicLinkSent";
+import { signInWithMagicLink } from "@/services/authService";
 
 export default function AuthPage() {
+  const [searchParams] = useSearchParams();
+  const [email, setEmail] = useState(searchParams.get("email") ?? "");
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      await signInWithMagicLink(email);
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setLoading(true);
+    try {
+      await signInWithMagicLink(email);
+    } catch {
+      // Silently handle — user can try again
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-[80vh]">
-      <Card padding="lg" className="w-full max-w-md">
-        <div className="text-center">
-          <div className="flex justify-center mb-4">
-            <AppIcon name="mail" className="w-10 h-10 text-primary" />
-          </div>
-          <h1 className="text-2xl font-bold text-foreground mb-2">Sign in</h1>
-          <p className="text-muted-foreground mb-6">
-            Enter your email and we'll send you a magic link
-          </p>
-          <div className="space-y-4">
-            <input
-              type="email"
-              placeholder="you@example.com"
-              className="w-full px-4 py-2.5 rounded-xl border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-              disabled
-            />
-            <Button fullWidth disabled>
-              Send Magic Link
-            </Button>
-          </div>
-          <p className="text-xs text-muted-foreground mt-4">
-            Coming soon — authentication will be implemented in a future feature.
-          </p>
+      <div className="bg-white rounded-xl border border-border p-10 w-full max-w-[440px]">
+        {/* Logo */}
+        <div className="flex flex-col items-center justify-center mb-8">
+          <Link to="/" className="flex flex-col items-center gap-3">
+            <div className="w-8 h-8 bg-black rounded-lg flex items-center justify-center">
+              <span className="text-primary font-extrabold text-lg leading-none">R</span>
+            </div>
+            <span className="font-extrabold text-lg text-foreground tracking-tight">RUCompliant</span>
+          </Link>
         </div>
-      </Card>
+
+        {sent ? (
+          <MagicLinkSent email={email} onResend={handleResend} />
+        ) : (
+          <>
+            {/* Headers */}
+            <div className="text-center mb-6">
+              <h1 className="font-extrabold text-[28px] text-foreground leading-tight tracking-[-0.3px] mb-2">
+                Create your free account
+              </h1>
+              <p className="font-normal text-sm text-muted-foreground">
+                Takes 2 minutes. No credit card needed.
+              </p>
+            </div>
+
+            {/* Form */}
+            <form onSubmit={handleSubmit} className="w-full mb-4">
+              <div className="mb-6">
+                <label htmlFor="email" className="block font-semibold text-xs text-foreground mb-2">
+                  Your email address
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="hello@yourbusiness.co.uk"
+                  className="w-full h-[44px] px-4 rounded-lg border border-border bg-white text-[15px] text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent placeholder-muted-foreground transition-all"
+                />
+              </div>
+
+              {error && (
+                <p className="text-sm text-destructive mb-4">{error}</p>
+              )}
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full h-[44px] bg-magenta text-white font-bold text-base rounded-lg hover:bg-magenta-600 transition-colors flex items-center justify-center mb-4 disabled:opacity-50"
+              >
+                {loading ? "Sending..." : "Create my account \u2014 it\u2019s free"}
+              </button>
+            </form>
+
+            {/* Security Note */}
+            <div className="flex items-center justify-center gap-2 mb-4">
+              <AppIcon name="lock" className="w-3 h-3 text-muted-foreground" />
+              <p className="font-normal text-xs text-muted-foreground text-center max-w-[280px]">
+                No password needed — we'll send you a magic link to sign in instantly.
+              </p>
+            </div>
+
+            {/* Divider */}
+            <div className="w-full h-px bg-border my-4" />
+
+            {/* Sign In Link */}
+            <div className="text-center mb-6">
+              <span className="text-[13px] text-muted-foreground">Already have an account?</span>
+              <button
+                type="button"
+                className="text-[13px] font-semibold text-primary hover:underline ml-1"
+              >
+                Sign in
+              </button>
+            </div>
+
+            {/* Terms */}
+            <div className="text-center">
+              <p className="text-[11px] text-muted-foreground/60">
+                By continuing you agree to our{" "}
+                <Link to="#" className="text-dusk hover:underline">Terms</Link> and{" "}
+                <Link to="#" className="text-dusk hover:underline">Privacy Policy</Link>.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Background decorative elements */}
+      <div className="fixed top-0 left-0 w-full h-full overflow-hidden -z-10 pointer-events-none">
+        <div className="absolute top-[-10%] left-[-5%] w-[40%] h-[40%] bg-primary/5 rounded-full blur-3xl" />
+        <div className="absolute bottom-[-10%] right-[-5%] w-[30%] h-[30%] bg-dusk/5 rounded-full blur-3xl" />
+      </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- **AuthPage**: Full signup/signin form matching UX design — centered card, logo, email input, "Create my account" CTA, security note, terms links, error handling
- **MagicLinkSent**: "Check your email" confirmation with email displayed and resend button
- **AuthCallbackPage**: Handles Supabase magic link redirect, routes to /onboarding (new) or /app/dashboard (returning)
- Pre-fills email from URL query params (from landing page EmailSignup)
- Decorative background blurs matching UX design

**Note**: This PR includes F-007 changes (auth service) as it was branched from that feature branch.

Closes #21

## Checks
- **Lint**: clean | **Tests**: 52/52 pass | **Build**: passes

## Test plan
- [ ] Visit /auth — see signup form with logo and email input
- [ ] Enter email, submit — see "Check your email" confirmation
- [ ] "Resend the link" button triggers re-send
- [ ] /auth?email=test@example.com pre-fills the email field
- [ ] Mobile responsive (375px)
- [ ] Error message shown on auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)