### PR TITLE
F-025: Account Settings page with modular cards and avatar upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Account Settings page with modular card layout (F-025): Personal Details, Company Info, VAT, Address, Directors
+- Avatar upload with zoom/reposition and drag-drop support
+- Reusable settings components: SettingsCard, SettingsField, SettingsToggle, AvatarUpload
+- Extended business_profiles schema with 16 new columns (Migration 002)
+- Sidebar: avatar initial links to settings, sign-out button
 - 5-question onboarding flow using QuestionFlow component (F-009)
 - Onboarding service: saves business profile, creates initial health score (Amber), creates domain scores, seeds calendar
 - Calendar seed service: auto-populates statutory deadlines based on business profile (F-010)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ src/
 │   ├── ui/         # Design system (shadcn primitives + custom composites)
 │   ├── layout/     # AppLayout, Sidebar, PublicLayout, MobileNav
 │   ├── auth/       # ProtectedRoute, AuthProvider, MagicLinkSent
+│   ├── settings/   # SettingsCard, SettingsField, SettingsToggle, AvatarUpload
+│   ├── landing/    # LandingNav, HeroHealthCard, EmailSignup, PricingCard, etc.
 │   └── shared/     # Reusable feature components (RagStatus, TaskList, QuestionFlow)
 ├── pages/          # Route-level page components
 ├── hooks/          # Custom React hooks (useCamelCase)

--- a/docs/design.md
+++ b/docs/design.md
@@ -73,6 +73,15 @@ Reusable components in `src/components/shared/` used across multiple modules:
 | `TaskList` / `TaskItem` | Task list with 3 variants (checklist/timeline/compact) — Dashboard, Concierge, Calendar |
 | `QuestionFlow` / `QuestionStep` | Multi-step question flow with 5 step types — Onboarding, contract generator |
 
+Settings components in `src/components/settings/`:
+
+| Component | Use case |
+|-----------|----------|
+| `SettingsCard` | Card wrapper with title + description for settings sections |
+| `SettingsField` | Labelled input field with consistent styling |
+| `SettingsToggle` | Toggle switch with label + description |
+| `AvatarUpload` | Drag-drop image upload with zoom/reposition |
+
 ### Adding New shadcn Components
 
 ```bash

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,25 +1,36 @@
 import { useEffect } from 'react'
 import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useAuthStore } from '@/stores/authStore'
+import { useProfileStore } from '@/stores/profileStore'
 import { checkOnboardingCompleted } from '@/services/authService'
+import { fetchProfile } from '@/services/accountService'
+
+async function loadUserData(userId: string) {
+  const completed = await checkOnboardingCompleted(userId)
+  useAuthStore.getState().setOnboardingCompleted(completed)
+
+  const profile = await fetchProfile(userId)
+  if (profile) {
+    useProfileStore.getState().setAvatarUrl(profile.avatar_url)
+    useProfileStore.getState().setName(profile.first_name, profile.last_name)
+  }
+}
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
-  const { setUser, setSession, setLoading, setOnboardingCompleted } = useAuthStore()
-
   useEffect(() => {
     if (!isSupabaseConfigured) {
-      setLoading(false)
+      useAuthStore.getState().setLoading(false)
       return
     }
 
-    // Get initial session — wait for onboarding check before setting loading false
+    const { setUser, setSession, setLoading } = useAuthStore.getState()
+
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session)
       setUser(session?.user ?? null)
 
       if (session?.user) {
-        const completed = await checkOnboardingCompleted(session.user.id)
-        setOnboardingCompleted(completed)
+        await loadUserData(session.user.id)
       }
 
       setLoading(false)
@@ -27,23 +38,23 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       setLoading(false)
     })
 
-    // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (_event, session) => {
-        setSession(session)
-        setUser(session?.user ?? null)
+        useAuthStore.getState().setSession(session)
+        useAuthStore.getState().setUser(session?.user ?? null)
 
         if (session?.user) {
-          const completed = await checkOnboardingCompleted(session.user.id)
-          setOnboardingCompleted(completed)
+          await loadUserData(session.user.id)
         } else {
-          setOnboardingCompleted(false)
+          useAuthStore.getState().setOnboardingCompleted(false)
+          useProfileStore.getState().setAvatarUrl(null)
+          useProfileStore.getState().setName(null, null)
         }
       }
     )
 
     return () => subscription.unsubscribe()
-  }, [setUser, setSession, setLoading, setOnboardingCompleted])
+  }, [])
 
   return <>{children}</>
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import { AppIcon } from '@/components/ui'
 import type { IconKey } from '@/components/ui/AppIcon'
 import { useAuthStore } from '@/stores/authStore'
+import { useProfileStore } from '@/stores/profileStore'
 import { signOut } from '@/services/authService'
 
 interface NavItem {
@@ -21,6 +22,7 @@ const navItems: NavItem[] = [
 export default function Sidebar() {
   const navigate = useNavigate()
   const user = useAuthStore((s) => s.user)
+  const { avatarUrl, firstName, lastName } = useProfileStore()
 
   const handleSignOut = async () => {
     await signOut()
@@ -69,10 +71,14 @@ export default function Sidebar() {
 
         {/* User + Sign out */}
         <div className="flex items-center gap-3 px-3 py-2.5">
-          <NavLink to="/app/settings" className="w-8 h-8 rounded-full bg-magenta/20 flex items-center justify-center shrink-0 hover:ring-2 hover:ring-primary transition-all">
-            <span className="text-xs font-bold text-primary uppercase">
-              {user?.email?.charAt(0) || '?'}
-            </span>
+          <NavLink to="/app/settings" className="w-8 h-8 rounded-full bg-magenta/20 flex items-center justify-center shrink-0 hover:ring-2 hover:ring-primary transition-all overflow-hidden">
+            {avatarUrl ? (
+              <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-xs font-bold text-primary uppercase">
+                {firstName ? `${firstName.charAt(0)}${lastName?.charAt(0) || ''}` : user?.email?.charAt(0) || '?'}
+              </span>
+            )}
           </NavLink>
           <div className="flex-1 min-w-0">
             <p className="text-xs font-medium text-white/80 truncate">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -69,11 +69,11 @@ export default function Sidebar() {
 
         {/* User + Sign out */}
         <div className="flex items-center gap-3 px-3 py-2.5">
-          <div className="w-8 h-8 rounded-full bg-magenta/20 flex items-center justify-center shrink-0">
+          <NavLink to="/app/settings" className="w-8 h-8 rounded-full bg-magenta/20 flex items-center justify-center shrink-0 hover:ring-2 hover:ring-primary transition-all">
             <span className="text-xs font-bold text-primary uppercase">
               {user?.email?.charAt(0) || '?'}
             </span>
-          </div>
+          </NavLink>
           <div className="flex-1 min-w-0">
             <p className="text-xs font-medium text-white/80 truncate">
               {user?.email || 'Account'}

--- a/src/components/settings/AvatarUpload.tsx
+++ b/src/components/settings/AvatarUpload.tsx
@@ -1,0 +1,182 @@
+import { useState, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import AppIcon from "@/components/ui/AppIcon";
+
+interface AvatarUploadProps {
+  currentUrl?: string | null;
+  initials: string;
+  onUpload: (file: File) => Promise<void>;
+  className?: string;
+}
+
+export default function AvatarUpload({
+  currentUrl,
+  initials,
+  onUpload,
+  className,
+}: AvatarUploadProps) {
+  const [preview, setPreview] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [showEditor, setShowEditor] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const isDragging = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+
+  const displayUrl = preview || currentUrl;
+
+  const handleFileSelect = (file: File) => {
+    if (!file.type.startsWith("image/")) return;
+    const url = URL.createObjectURL(file);
+    setPreview(url);
+    setSelectedFile(file);
+    setZoom(1);
+    setPosition({ x: 0, y: 0 });
+    setShowEditor(true);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleSave = async () => {
+    if (!selectedFile) return;
+    setUploading(true);
+    try {
+      await onUpload(selectedFile);
+      setShowEditor(false);
+    } catch {
+      // Error handled by parent
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowEditor(false);
+    setPreview(null);
+    setSelectedFile(null);
+  };
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    isDragging.current = true;
+    dragStart.current = { x: e.clientX - position.x, y: e.clientY - position.y };
+  }, [position]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current) return;
+    setPosition({
+      x: e.clientX - dragStart.current.x,
+      y: e.clientY - dragStart.current.y,
+    });
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  return (
+    <div className={cn("flex flex-col items-center gap-4", className)}>
+      {showEditor ? (
+        <div className="flex flex-col items-center gap-4">
+          {/* Preview with crop */}
+          <div
+            className="w-32 h-32 rounded-full overflow-hidden border-2 border-border cursor-move relative"
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
+          >
+            <img
+              src={preview || ""}
+              alt="Preview"
+              className="w-full h-full object-cover select-none pointer-events-none"
+              style={{
+                transform: `scale(${zoom}) translate(${position.x / zoom}px, ${position.y / zoom}px)`,
+              }}
+              draggable={false}
+            />
+          </div>
+
+          {/* Zoom slider */}
+          <div className="flex items-center gap-3 w-48">
+            <AppIcon name="minimize" className="w-3 h-3 text-muted-foreground" />
+            <input
+              type="range"
+              min="1"
+              max="3"
+              step="0.1"
+              value={zoom}
+              onChange={(e) => setZoom(parseFloat(e.target.value))}
+              className="flex-1 accent-primary"
+            />
+            <AppIcon name="maximize" className="w-3 h-3 text-muted-foreground" />
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <button
+              onClick={handleCancel}
+              className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-surface transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={uploading}
+              className="px-4 py-2 text-sm font-bold text-white bg-magenta rounded-lg hover:bg-magenta-600 transition-colors disabled:opacity-50"
+            >
+              {uploading ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Avatar display */}
+          <div
+            className={cn(
+              "w-20 h-20 rounded-full flex items-center justify-center border-2 transition-colors cursor-pointer overflow-hidden",
+              dragOver ? "border-primary bg-primary/5" : "border-border",
+            )}
+            onClick={() => fileInputRef.current?.click()}
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleDrop}
+          >
+            {displayUrl ? (
+              <img src={displayUrl} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-2xl font-bold text-primary uppercase">{initials}</span>
+            )}
+          </div>
+
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="text-sm font-semibold text-primary hover:underline"
+          >
+            {displayUrl ? "Change photo" : "Upload photo"}
+          </button>
+        </>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleInputChange}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/src/components/settings/SettingsCard.tsx
+++ b/src/components/settings/SettingsCard.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface SettingsCardProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function SettingsCard({ title, description, children, className }: SettingsCardProps) {
+  return (
+    <div className={cn("bg-white rounded-xl border border-border p-6", className)}>
+      <div className="mb-5">
+        <h3 className="font-bold text-base text-foreground">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground mt-1">{description}</p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsField.tsx
+++ b/src/components/settings/SettingsField.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+interface SettingsFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: "text" | "email" | "tel" | "url" | "date" | "number";
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function SettingsField({
+  label,
+  value,
+  onChange,
+  type = "text",
+  placeholder,
+  disabled = false,
+  className,
+}: SettingsFieldProps) {
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <label className="block text-xs font-semibold text-foreground">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="w-full h-[40px] px-3 rounded-lg border border-border bg-white text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent placeholder-muted-foreground transition-all disabled:opacity-50 disabled:bg-surface"
+      />
+    </div>
+  );
+}

--- a/src/components/settings/SettingsToggle.tsx
+++ b/src/components/settings/SettingsToggle.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+
+interface SettingsToggleProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+}
+
+export default function SettingsToggle({
+  label,
+  description,
+  checked,
+  onChange,
+  className,
+}: SettingsToggleProps) {
+  return (
+    <div className={cn("flex items-center justify-between gap-4", className)}>
+      <div>
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors",
+          checked ? "bg-primary" : "bg-border"
+        )}
+      >
+        <span
+          className={cn(
+            "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform mt-0.5",
+            checked ? "translate-x-[22px] ml-0" : "translate-x-0.5"
+          )}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuthStore } from "@/stores/authStore";
+import { useProfileStore } from "@/stores/profileStore";
 import { fetchProfile, updateProfile, uploadAvatar } from "@/services/accountService";
 import { LoadingSpinner } from "@/components/ui";
 import AppIcon from "@/components/ui/AppIcon";
@@ -17,6 +18,7 @@ const BUSINESS_TYPE_LABELS: Record<string, string> = {
 
 export default function SettingsPage() {
   const user = useAuthStore((s) => s.user);
+  const { setAvatarUrl, setName } = useProfileStore();
   const [profile, setProfile] = useState<BusinessProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -26,9 +28,13 @@ export default function SettingsPage() {
     if (!user) return;
     fetchProfile(user.id).then((p) => {
       setProfile(p);
+      if (p) {
+        setAvatarUrl(p.avatar_url);
+        setName(p.first_name, p.last_name);
+      }
       setLoading(false);
     });
-  }, [user]);
+  }, [user, setAvatarUrl, setName]);
 
   const handleUpdate = useCallback(
     (field: string, value: string | boolean | number | null) => {
@@ -46,6 +52,7 @@ export default function SettingsPage() {
       const { id, user_id, created_at, updated_at, ...updates } = profile;
       void id; void user_id; void created_at; void updated_at;
       await updateProfile(user.id, updates as Partial<BusinessProfile>);
+      setName(profile.first_name, profile.last_name);
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
@@ -59,6 +66,7 @@ export default function SettingsPage() {
     if (!user) return;
     const url = await uploadAvatar(user.id, file);
     setProfile((prev) => prev ? { ...prev, avatar_url: url } as BusinessProfile : prev);
+    setAvatarUrl(url);
   };
 
   if (loading) {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,17 +1,306 @@
-import { Card, AppIcon } from '@/components/ui'
+import { useState, useEffect, useCallback } from "react";
+import { useAuthStore } from "@/stores/authStore";
+import { fetchProfile, updateProfile, uploadAvatar } from "@/services/accountService";
+import { LoadingSpinner } from "@/components/ui";
+import AppIcon from "@/components/ui/AppIcon";
+import SettingsCard from "@/components/settings/SettingsCard";
+import SettingsField from "@/components/settings/SettingsField";
+import SettingsToggle from "@/components/settings/SettingsToggle";
+import AvatarUpload from "@/components/settings/AvatarUpload";
+import type { BusinessProfile } from "@/types";
+
+const BUSINESS_TYPE_LABELS: Record<string, string> = {
+  sole_trader: "Sole Trader / Self-employed",
+  limited_company: "Limited Company",
+  partnership: "Partnership",
+};
 
 export default function SettingsPage() {
-  return (
-    <div>
-      <div className="flex items-center gap-3 mb-6">
-        <AppIcon name="settings" className="w-7 h-7 text-primary" />
-        <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+  const user = useAuthStore((s) => s.user);
+  const [profile, setProfile] = useState<BusinessProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    fetchProfile(user.id).then((p) => {
+      setProfile(p);
+      setLoading(false);
+    });
+  }, [user]);
+
+  const handleUpdate = useCallback(
+    (field: string, value: string | boolean | number | null) => {
+      setProfile((prev) => prev ? { ...prev, [field]: value } as BusinessProfile : prev);
+      setSaved(false);
+    },
+    []
+  );
+
+  const handleSave = async () => {
+    if (!user || !profile) return;
+    setSaving(true);
+    try {
+      // Strip read-only fields before sending to Supabase
+      const { id, user_id, created_at, updated_at, ...updates } = profile;
+      void id; void user_id; void created_at; void updated_at;
+      await updateProfile(user.id, updates as Partial<BusinessProfile>);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (err) {
+      console.error("Failed to save:", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAvatarUpload = async (file: File) => {
+    if (!user) return;
+    const url = await uploadAvatar(user.id, file);
+    setProfile((prev) => prev ? { ...prev, avatar_url: url } as BusinessProfile : prev);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <LoadingSpinner size="lg" message="Loading settings..." centered />
       </div>
-      <Card padding="lg">
-        <p className="text-muted-foreground">
-          Account settings and preferences will appear here. Coming soon.
-        </p>
-      </Card>
+    );
+  }
+
+  const initials = profile?.first_name
+    ? `${profile.first_name.charAt(0)}${profile.last_name?.charAt(0) || ""}`
+    : user?.email?.charAt(0) || "?";
+
+  const directors = Array.isArray(profile?.directors) ? profile.directors as string[] : [];
+
+  return (
+    <div className="max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Account Settings</h1>
+          <p className="text-sm text-muted-foreground mt-1">Manage your profile and company details</p>
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={saving || saved}
+          className="h-[40px] px-5 bg-magenta text-white font-bold text-sm rounded-lg hover:bg-magenta-600 transition-colors disabled:opacity-50 flex items-center gap-2"
+        >
+          {saving ? (
+            "Saving..."
+          ) : saved ? (
+            <>
+              <AppIcon name="check" className="w-4 h-4" />
+              Saved
+            </>
+          ) : (
+            "Save changes"
+          )}
+        </button>
+      </div>
+
+      <div className="space-y-6">
+        {/* Personal Details */}
+        <SettingsCard title="Personal Details" description="Your name and contact information">
+          <div className="flex flex-col sm:flex-row gap-6">
+            <AvatarUpload
+              currentUrl={profile?.avatar_url}
+              initials={initials}
+              onUpload={handleAvatarUpload}
+              className="sm:shrink-0"
+            />
+            <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <SettingsField
+                label="First name"
+                value={profile?.first_name || ""}
+                onChange={(v) => handleUpdate("first_name", v)}
+                placeholder="Sarah"
+              />
+              <SettingsField
+                label="Last name"
+                value={profile?.last_name || ""}
+                onChange={(v) => handleUpdate("last_name", v)}
+                placeholder="Thompson"
+              />
+              <SettingsField
+                label="Email address"
+                value={user?.email || ""}
+                onChange={() => {}}
+                type="email"
+                disabled
+              />
+              <SettingsField
+                label="Job title"
+                value={profile?.job_title || ""}
+                onChange={(v) => handleUpdate("job_title", v)}
+                placeholder="Owner"
+              />
+              <SettingsField
+                label="Phone"
+                value={profile?.phone || ""}
+                onChange={(v) => handleUpdate("phone", v)}
+                type="tel"
+                placeholder="07700 123456"
+              />
+              <SettingsField
+                label="Website"
+                value={profile?.website || ""}
+                onChange={(v) => handleUpdate("website", v)}
+                type="url"
+                placeholder="www.mybusiness.co.uk"
+              />
+            </div>
+          </div>
+        </SettingsCard>
+
+        {/* Company Information */}
+        <SettingsCard title="Company Information" description="Your business registration details">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <SettingsField
+              label="Company name"
+              value={profile?.company_name || ""}
+              onChange={(v) => handleUpdate("company_name", v)}
+              placeholder="My Business Ltd"
+              className="sm:col-span-2"
+            />
+            <SettingsField
+              label="Business structure"
+              value={BUSINESS_TYPE_LABELS[profile?.business_type || ""] || ""}
+              onChange={() => {}}
+              disabled
+            />
+            <SettingsField
+              label="Industry sector"
+              value={profile?.sector || ""}
+              onChange={(v) => handleUpdate("sector", v)}
+              placeholder="Professional services"
+            />
+            {profile?.business_type === "limited_company" && (
+              <>
+                <SettingsField
+                  label="Company number"
+                  value={profile?.company_number || ""}
+                  onChange={(v) => handleUpdate("company_number", v)}
+                  placeholder="12345678"
+                />
+                <SettingsField
+                  label="Date incorporated"
+                  value={profile?.date_incorporated || ""}
+                  onChange={(v) => handleUpdate("date_incorporated", v)}
+                  type="date"
+                />
+              </>
+            )}
+            <SettingsField
+              label="Number of employees"
+              value={String(profile?.headcount || 1)}
+              onChange={(v) => handleUpdate("headcount", parseInt(v) || 1)}
+              type="number"
+            />
+            <SettingsField
+              label="Trading since"
+              value={profile?.trading_start_date || ""}
+              onChange={(v) => handleUpdate("trading_start_date", v)}
+              type="date"
+            />
+          </div>
+        </SettingsCard>
+
+        {/* VAT Details */}
+        <SettingsCard title="VAT Registration">
+          <div className="space-y-4">
+            <SettingsToggle
+              label="VAT registered"
+              description="Toggle on if your business is registered for VAT with HMRC"
+              checked={profile?.vat_registered || false}
+              onChange={(v) => handleUpdate("vat_registered", v)}
+            />
+            {profile?.vat_registered && (
+              <SettingsField
+                label="VAT number"
+                value={profile?.vat_number || ""}
+                onChange={(v) => handleUpdate("vat_number", v)}
+                placeholder="GB 123 4567 89"
+              />
+            )}
+          </div>
+        </SettingsCard>
+
+        {/* Registered Address */}
+        <SettingsCard title="Registered Address" description="Your official business address">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <SettingsField
+              label="Address line 1"
+              value={profile?.address_line_1 || ""}
+              onChange={(v) => handleUpdate("address_line_1", v)}
+              placeholder="123 High Street"
+              className="sm:col-span-2"
+            />
+            <SettingsField
+              label="Address line 2"
+              value={profile?.address_line_2 || ""}
+              onChange={(v) => handleUpdate("address_line_2", v)}
+              placeholder="Suite 4"
+              className="sm:col-span-2"
+            />
+            <SettingsField
+              label="City"
+              value={profile?.city || ""}
+              onChange={(v) => handleUpdate("city", v)}
+              placeholder="London"
+            />
+            <SettingsField
+              label="Postcode"
+              value={profile?.postcode || ""}
+              onChange={(v) => handleUpdate("postcode", v)}
+              placeholder="SW1A 1AA"
+            />
+          </div>
+        </SettingsCard>
+
+        {/* Directors (Ltd company only) */}
+        {profile?.business_type === "limited_company" && (
+          <SettingsCard title="Company Directors" description="People registered as directors at Companies House">
+            <div className="space-y-3">
+              {directors.map((director, i) => (
+                <div key={i} className="flex items-center gap-3">
+                  <SettingsField
+                    label={i === 0 ? "Director name" : ""}
+                    value={String(director)}
+                    onChange={(v) => {
+                      const updated = [...directors];
+                      updated[i] = v;
+                      handleUpdate("directors", updated as unknown as string);
+                    }}
+                    placeholder="Full name"
+                    className="flex-1"
+                  />
+                  <button
+                    onClick={() => {
+                      const updated = directors.filter((_, idx) => idx !== i);
+                      handleUpdate("directors", updated as unknown as string);
+                    }}
+                    className="text-muted-foreground hover:text-destructive transition-colors mt-auto pb-2"
+                  >
+                    <AppIcon name="x" className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+              <button
+                onClick={() => {
+                  handleUpdate("directors", [...directors, ""] as unknown as string);
+                }}
+                className="text-sm font-semibold text-primary hover:underline flex items-center gap-1"
+              >
+                <AppIcon name="plus" className="w-4 h-4" />
+                Add director
+              </button>
+            </div>
+          </SettingsCard>
+        )}
+      </div>
     </div>
-  )
+  );
 }

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -1,0 +1,41 @@
+import { supabase } from '@/lib/supabase'
+import type { BusinessProfile } from '@/types'
+
+export async function fetchProfile(userId: string): Promise<BusinessProfile | null> {
+  const { data } = await supabase
+    .from('business_profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  return data
+}
+
+export async function updateProfile(userId: string, updates: Partial<BusinessProfile>) {
+  const { error } = await supabase
+    .from('business_profiles')
+    .update(updates)
+    .eq('user_id', userId)
+
+  if (error) throw error
+}
+
+export async function uploadAvatar(userId: string, file: File): Promise<string> {
+  const ext = file.name.split('.').pop()
+  const path = `avatars/${userId}.${ext}`
+
+  const { error: uploadError } = await supabase.storage
+    .from('avatars')
+    .upload(path, file, { upsert: true })
+
+  if (uploadError) throw uploadError
+
+  const { data } = supabase.storage
+    .from('avatars')
+    .getPublicUrl(path)
+
+  // Save URL to profile
+  await updateProfile(userId, { avatar_url: data.publicUrl } as Partial<BusinessProfile>)
+
+  return data.publicUrl
+}

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -22,7 +22,7 @@ export async function updateProfile(userId: string, updates: Partial<BusinessPro
 
 export async function uploadAvatar(userId: string, file: File): Promise<string> {
   const ext = file.name.split('.').pop()
-  const path = `avatars/${userId}.${ext}`
+  const path = `${userId}.${ext}`
 
   const { error: uploadError } = await supabase.storage
     .from('avatars')

--- a/src/stores/profileStore.ts
+++ b/src/stores/profileStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+interface ProfileState {
+  avatarUrl: string | null
+  firstName: string | null
+  lastName: string | null
+  setAvatarUrl: (url: string | null) => void
+  setName: (first: string | null, last: string | null) => void
+}
+
+export const useProfileStore = create<ProfileState>((set) => ({
+  avatarUrl: null,
+  firstName: null,
+  lastName: null,
+  setAvatarUrl: (url) => set({ avatarUrl: url }),
+  setName: (first, last) => set({ firstName: first, lastName: last }),
+}))

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -75,40 +75,88 @@ export type Database = {
       }
       business_profiles: {
         Row: {
+          address_line_1: string | null
+          address_line_2: string | null
+          avatar_url: string | null
           business_type: Database["public"]["Enums"]["business_type"]
+          city: string | null
+          company_name: string | null
+          company_number: string | null
+          country: string | null
           created_at: string
+          date_incorporated: string | null
+          directors: Json | null
+          first_name: string | null
           headcount: number
           id: string
+          job_title: string | null
+          last_name: string | null
           onboarding_completed: boolean
+          phone: string | null
+          postcode: string | null
           sector: string | null
           trading_start_date: string | null
           updated_at: string
           user_id: string
+          vat_number: string | null
           vat_registered: boolean | null
+          website: string | null
         }
         Insert: {
+          address_line_1?: string | null
+          address_line_2?: string | null
+          avatar_url?: string | null
           business_type: Database["public"]["Enums"]["business_type"]
+          city?: string | null
+          company_name?: string | null
+          company_number?: string | null
+          country?: string | null
           created_at?: string
+          date_incorporated?: string | null
+          directors?: Json | null
+          first_name?: string | null
           headcount?: number
           id?: string
+          job_title?: string | null
+          last_name?: string | null
           onboarding_completed?: boolean
+          phone?: string | null
+          postcode?: string | null
           sector?: string | null
           trading_start_date?: string | null
           updated_at?: string
           user_id: string
+          vat_number?: string | null
           vat_registered?: boolean | null
+          website?: string | null
         }
         Update: {
+          address_line_1?: string | null
+          address_line_2?: string | null
+          avatar_url?: string | null
           business_type?: Database["public"]["Enums"]["business_type"]
+          city?: string | null
+          company_name?: string | null
+          company_number?: string | null
+          country?: string | null
           created_at?: string
+          date_incorporated?: string | null
+          directors?: Json | null
+          first_name?: string | null
           headcount?: number
           id?: string
+          job_title?: string | null
+          last_name?: string | null
           onboarding_completed?: boolean
+          phone?: string | null
+          postcode?: string | null
           sector?: string | null
           trading_start_date?: string | null
           updated_at?: string
           user_id?: string
+          vat_number?: string | null
           vat_registered?: boolean | null
+          website?: string | null
         }
         Relationships: []
       }
@@ -640,3 +688,42 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      action_type: [
+        "external_link",
+        "internal_workflow",
+        "mark_done",
+        "upload_document",
+      ],
+      business_type: ["sole_trader", "limited_company", "partnership"],
+      document_category: [
+        "formation",
+        "contracts",
+        "policies",
+        "insurance",
+        "tax_accounts",
+        "health_safety",
+        "training",
+      ],
+      health_status: ["green", "amber", "red"],
+      message_role: ["user", "assistant"],
+      plan_type: ["monthly", "annual"],
+      subscription_status: [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+      ],
+      task_type: [
+        "statutory_deadline",
+        "compliance_action",
+        "trigger_event",
+        "review_renewal",
+      ],
+    },
+  },
+} as const

--- a/supabase/migrations/20260331_002_extend_business_profiles.sql
+++ b/supabase/migrations/20260331_002_extend_business_profiles.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- Extend business_profiles with company and user details
+-- Migration 002: Account & company information for Settings page
+-- ============================================================================
+
+ALTER TABLE business_profiles
+  ADD COLUMN IF NOT EXISTS company_name text,
+  ADD COLUMN IF NOT EXISTS company_number text,
+  ADD COLUMN IF NOT EXISTS date_incorporated date,
+  ADD COLUMN IF NOT EXISTS vat_number text,
+  ADD COLUMN IF NOT EXISTS address_line_1 text,
+  ADD COLUMN IF NOT EXISTS address_line_2 text,
+  ADD COLUMN IF NOT EXISTS city text,
+  ADD COLUMN IF NOT EXISTS postcode text,
+  ADD COLUMN IF NOT EXISTS country text DEFAULT 'United Kingdom',
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS website text,
+  ADD COLUMN IF NOT EXISTS avatar_url text,
+  ADD COLUMN IF NOT EXISTS first_name text,
+  ADD COLUMN IF NOT EXISTS last_name text,
+  ADD COLUMN IF NOT EXISTS job_title text,
+  ADD COLUMN IF NOT EXISTS directors jsonb DEFAULT '[]';


### PR DESCRIPTION
## Summary
Full Account Settings page with 5 modular card sections and avatar upload.

### Sections
- **Personal Details** — name, email (read-only), job title, phone, website + avatar upload with zoom/reposition
- **Company Information** — company name, structure (read-only from onboarding), sector, company number, incorporation date, headcount, trading date
- **VAT Registration** — toggle with conditional VAT number field
- **Registered Address** — address lines, city, postcode
- **Company Directors** — add/remove directors (Ltd company only)

### Components Created
- `SettingsCard` — reusable card wrapper with title + description
- `SettingsField` — labelled input field
- `SettingsToggle` — switch with label + description
- `AvatarUpload` — drag-drop upload with zoom slider and reposition

### Database
- Migration 002: 16 new columns on business_profiles

Closes #28

## Checks
- **Lint**: clean | **Tests**: 52/52 pass | **Build**: passes

## Test plan
- [ ] Navigate to /app/settings — see all 5 card sections
- [ ] Edit fields and click Save — changes persist on reload
- [ ] Toggle VAT — VAT number field appears/disappears
- [ ] Upload avatar — zoom slider and reposition work
- [ ] Ltd company: Directors section visible with add/remove
- [ ] Sole trader: Directors section hidden, company number hidden
- [ ] Click avatar initial in sidebar → navigates to settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)