### PR TITLE
F-011: Health Score service, store, and calculation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Health Score service and store — fetches overall status, domain scores, next actions from Supabase (F-011)
+- calculateOverallStatus: worst single domain determines overall score (PRD rule)
 - Account Settings page with modular card layout (F-025): Personal Details, Company Info, VAT, Address, Directors
 - Avatar upload with zoom/reposition and drag-drop support
 - Reusable settings components: SettingsCard, SettingsField, SettingsToggle, AvatarUpload

--- a/src/services/healthScoreService.test.ts
+++ b/src/services/healthScoreService.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { calculateOverallStatus } from './healthScoreService'
+import type { DomainScore } from './healthScoreService'
+
+const makeDomain = (name: string, status: 'green' | 'amber' | 'red'): DomainScore => ({
+  id: `id-${name}`,
+  domainId: `id-${name}`,
+  domainName: name,
+  domainDescription: '',
+  displayOrder: 1,
+  status,
+})
+
+describe('calculateOverallStatus', () => {
+  it('returns green when all domains are green', () => {
+    const scores = [
+      makeDomain('Formation', 'green'),
+      makeDomain('Tax', 'green'),
+      makeDomain('Data', 'green'),
+    ]
+    expect(calculateOverallStatus(scores)).toBe('green')
+  })
+
+  it('returns amber when any domain is amber', () => {
+    const scores = [
+      makeDomain('Formation', 'green'),
+      makeDomain('Tax', 'amber'),
+      makeDomain('Data', 'green'),
+    ]
+    expect(calculateOverallStatus(scores)).toBe('amber')
+  })
+
+  it('returns red when any domain is red', () => {
+    const scores = [
+      makeDomain('Formation', 'green'),
+      makeDomain('Tax', 'amber'),
+      makeDomain('Data', 'red'),
+    ]
+    expect(calculateOverallStatus(scores)).toBe('red')
+  })
+
+  it('returns red even if only one domain is red among greens', () => {
+    const scores = [
+      makeDomain('Formation', 'green'),
+      makeDomain('Tax', 'green'),
+      makeDomain('Data', 'green'),
+      makeDomain('H&S', 'green'),
+      makeDomain('Employment', 'red'),
+      makeDomain('Insurance', 'green'),
+    ]
+    expect(calculateOverallStatus(scores)).toBe('red')
+  })
+
+  it('returns green for empty array', () => {
+    expect(calculateOverallStatus([])).toBe('green')
+  })
+})

--- a/src/services/healthScoreService.ts
+++ b/src/services/healthScoreService.ts
@@ -1,0 +1,130 @@
+import { supabase } from '@/lib/supabase'
+import type { HealthStatus } from '@/types'
+
+export interface DomainScore {
+  id: string
+  domainId: string
+  domainName: string
+  domainDescription: string
+  displayOrder: number
+  status: HealthStatus
+}
+
+export interface HealthScoreData {
+  overallStatus: HealthStatus
+  previousStatus: HealthStatus | null
+  calculatedAt: string
+}
+
+export interface NextAction {
+  id: string
+  title: string
+  description: string | null
+  dueDate: string
+  taskType: string
+  completed: boolean
+  domainName: string | null
+  status: HealthStatus
+}
+
+export async function fetchHealthScore(userId: string): Promise<HealthScoreData | null> {
+  const { data } = await supabase
+    .from('health_scores')
+    .select('overall_status, previous_status, calculated_at')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (!data) return null
+
+  return {
+    overallStatus: data.overall_status,
+    previousStatus: data.previous_status,
+    calculatedAt: data.calculated_at,
+  }
+}
+
+export async function fetchDomainScores(userId: string): Promise<DomainScore[]> {
+  // Fetch domains and user scores in parallel
+  const [{ data: domains }, { data: scores }] = await Promise.all([
+    supabase
+      .from('compliance_domains')
+      .select('id, name, description, display_order')
+      .order('display_order'),
+    supabase
+      .from('compliance_domain_scores')
+      .select('domain_id, status')
+      .eq('user_id', userId),
+  ])
+
+  if (!domains) return []
+
+  const scoreMap = new Map(scores?.map(s => [s.domain_id, s.status]) ?? [])
+
+  return domains.map(domain => ({
+    id: domain.id,
+    domainId: domain.id,
+    domainName: domain.name,
+    domainDescription: domain.description,
+    displayOrder: domain.display_order,
+    status: (scoreMap.get(domain.id) as HealthStatus) ?? 'amber',
+  }))
+}
+
+export async function fetchNextActions(userId: string, limit = 3): Promise<NextAction[]> {
+  const today = new Date().toISOString().split('T')[0]
+
+  const { data } = await supabase
+    .from('task_calendar')
+    .select(`
+      id,
+      title,
+      description,
+      due_date,
+      task_type,
+      completed,
+      domain_id,
+      compliance_domains(name)
+    `)
+    .eq('user_id', userId)
+    .eq('completed', false)
+    .order('due_date', { ascending: true })
+    .limit(limit)
+
+  if (!data) return []
+
+  return data.map(task => {
+    // Determine urgency status based on due date
+    const dueDate = task.due_date
+    const daysUntilDue = Math.ceil(
+      (new Date(dueDate).getTime() - new Date(today).getTime()) / (1000 * 60 * 60 * 24)
+    )
+
+    let status: HealthStatus = 'green'
+    if (daysUntilDue <= 0) status = 'red'
+    else if (daysUntilDue <= 14) status = 'amber'
+
+    // Handle the joined domain name
+    const domainData = task.compliance_domains as unknown as { name: string } | null
+
+    return {
+      id: task.id,
+      title: task.title,
+      description: task.description,
+      dueDate: task.due_date,
+      taskType: task.task_type,
+      completed: task.completed,
+      domainName: domainData?.name ?? null,
+      status,
+    }
+  })
+}
+
+/**
+ * Calculate overall health status from domain scores.
+ * Rule: overall = worst single domain (PRD Section 5.2)
+ */
+export function calculateOverallStatus(domainScores: DomainScore[]): HealthStatus {
+  if (domainScores.some(d => d.status === 'red')) return 'red'
+  if (domainScores.some(d => d.status === 'amber')) return 'amber'
+  return 'green'
+}

--- a/src/stores/healthScoreStore.ts
+++ b/src/stores/healthScoreStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand'
+import type { HealthStatus } from '@/types'
+import type { DomainScore, NextAction } from '@/services/healthScoreService'
+
+interface HealthScoreState {
+  overallStatus: HealthStatus | null
+  previousStatus: HealthStatus | null
+  calculatedAt: string | null
+  domainScores: DomainScore[]
+  nextActions: NextAction[]
+  loading: boolean
+  setOverallStatus: (status: HealthStatus, previous: HealthStatus | null, calculatedAt: string) => void
+  setDomainScores: (scores: DomainScore[]) => void
+  setNextActions: (actions: NextAction[]) => void
+  setLoading: (loading: boolean) => void
+}
+
+export const useHealthScoreStore = create<HealthScoreState>((set) => ({
+  overallStatus: null,
+  previousStatus: null,
+  calculatedAt: null,
+  domainScores: [],
+  nextActions: [],
+  loading: true,
+  setOverallStatus: (status, previous, calculatedAt) =>
+    set({ overallStatus: status, previousStatus: previous, calculatedAt }),
+  setDomainScores: (scores) => set({ domainScores: scores }),
+  setNextActions: (actions) => set({ nextActions: actions }),
+  setLoading: (loading) => set({ loading }),
+}))


### PR DESCRIPTION
## Summary
- `healthScoreService`: fetchHealthScore, fetchDomainScores, fetchNextActions, calculateOverallStatus
- `healthScoreStore` (Zustand): overallStatus, previousStatus, domainScores, nextActions, loading
- Overall score rule: worst single domain determines overall (if any Red → overall Red)
- Next actions sorted by due date with urgency colouring (red: overdue, amber: ≤14 days)
- 5 unit tests for calculateOverallStatus

Closes #30

## Checks
- **Lint**: clean | **Tests**: 57/57 pass (5 new) | **Build**: passes

## Test plan
- [ ] calculateOverallStatus returns correct RAG for all combinations
- [ ] fetchDomainScores returns all 6 domains with correct statuses
- [ ] fetchNextActions returns top 3 tasks sorted by urgency

🤖 Generated with [Claude Code](https://claude.com/claude-code)