### PR TITLE
F-014: Concierge Journey page with stages, progress, and task checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Concierge Journey page with stage selector, progress bar, and task checklist (F-014)
+- StageSelector component with completion indicators and progress counts
+- StageProgress component with percentage bar and stage complete celebration
+- External link tasks open in new tab, internal tasks navigate in-app
 - Concierge service and store — fetch stages, tasks (filtered by business profile), mark done, track progress (F-013)
 - 18 concierge tasks seeded across 3 stages with applies_to filtering (Migration 003)
 - Dashboard page with Health Score hero, Domain Breakdown (6 cards, red-first sorting), and Next 3 Actions (F-012)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ src/
 │   ├── layout/     # AppLayout, Sidebar, PublicLayout, MobileNav
 │   ├── auth/       # ProtectedRoute, AuthProvider, MagicLinkSent
 │   ├── dashboard/  # DomainBreakdown, NextActions
+│   ├── concierge/  # StageSelector, StageProgress
 │   ├── settings/   # SettingsCard, SettingsField, SettingsToggle, AvatarUpload
 │   ├── landing/    # LandingNav, HeroHealthCard, EmailSignup, PricingCard, etc.
 │   └── shared/     # Reusable feature components (RagStatus, TaskList, QuestionFlow)

--- a/src/components/concierge/StageProgress.tsx
+++ b/src/components/concierge/StageProgress.tsx
@@ -1,0 +1,34 @@
+import { ProgressBar } from "@/components/ui";
+import AppIcon from "@/components/ui/AppIcon";
+import type { StageProgress as StageProgressData } from "@/services/conciergeService";
+
+interface StageProgressProps {
+  progress: StageProgressData;
+  stageName: string;
+}
+
+export default function StageProgress({ progress, stageName }: StageProgressProps) {
+  const isComplete = progress.total > 0 && progress.percentage === 100;
+
+  return (
+    <div className="bg-white rounded-xl border border-border p-5">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-semibold text-foreground">{stageName}</span>
+        <span className="text-xs font-medium text-muted-foreground">
+          {progress.completed} of {progress.total} tasks
+        </span>
+      </div>
+      <ProgressBar
+        value={progress.percentage}
+        color={isComplete ? "success" : "primary"}
+        size="md"
+      />
+      {isComplete && (
+        <div className="flex items-center gap-2 mt-3 text-emerald">
+          <AppIcon name="check-circle" className="w-4 h-4" />
+          <span className="text-sm font-semibold">Stage complete!</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/concierge/StageSelector.tsx
+++ b/src/components/concierge/StageSelector.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/utils";
+import AppIcon from "@/components/ui/AppIcon";
+import type { ConciergeStage } from "@/services/conciergeService";
+import type { ConciergeTaskData } from "@/services/conciergeService";
+import { getStageProgress } from "@/services/conciergeService";
+
+interface StageSelectorProps {
+  stages: ConciergeStage[];
+  currentIndex: number;
+  tasksByStage: Record<string, ConciergeTaskData[]>;
+  onSelect: (index: number) => void;
+}
+
+export default function StageSelector({
+  stages,
+  currentIndex,
+  tasksByStage,
+  onSelect,
+}: StageSelectorProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3">
+      {stages.map((stage, i) => {
+        const tasks = tasksByStage[stage.id] ?? [];
+        const progress = getStageProgress(tasks);
+        const isActive = i === currentIndex;
+        const isComplete = progress.total > 0 && progress.percentage === 100;
+
+        return (
+          <button
+            key={stage.id}
+            onClick={() => onSelect(i)}
+            className={cn(
+              "flex-1 flex items-center gap-3 p-4 rounded-xl border transition-all text-left",
+              isActive
+                ? "border-primary bg-primary/5"
+                : "border-border bg-white hover:border-primary/30"
+            )}
+          >
+            {/* Stage number / check */}
+            <div className={cn(
+              "w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-sm font-bold",
+              isComplete
+                ? "bg-emerald text-white"
+                : isActive
+                  ? "bg-primary text-white"
+                  : "bg-surface text-muted-foreground"
+            )}>
+              {isComplete ? (
+                <AppIcon name="check" className="w-4 h-4" />
+              ) : (
+                stage.stageNumber
+              )}
+            </div>
+
+            {/* Stage info */}
+            <div className="flex-1 min-w-0">
+              <p className={cn(
+                "text-sm font-semibold truncate",
+                isActive ? "text-foreground" : "text-muted-foreground"
+              )}>
+                {stage.name}
+              </p>
+              {tasks.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {progress.completed}/{progress.total} done
+                </p>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/ConciergePage.tsx
+++ b/src/pages/ConciergePage.tsx
@@ -1,17 +1,167 @@
-import { Card, AppIcon } from '@/components/ui'
+import { useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+import { useConciergeStore } from "@/stores/conciergeStore";
+import {
+  fetchStages,
+  fetchTasksForStage,
+  markTaskDone,
+  getStageProgress,
+  getTaskStatus,
+} from "@/services/conciergeService";
+import { fetchProfile } from "@/services/accountService";
+import { LoadingSpinner } from "@/components/ui";
+import TaskList from "@/components/shared/TaskList";
+import type { TaskItemData } from "@/components/shared/TaskItem";
+import StageSelector from "@/components/concierge/StageSelector";
+import StageProgress from "@/components/concierge/StageProgress";
 
 export default function ConciergePage() {
-  return (
-    <div>
-      <div className="flex items-center gap-3 mb-6">
-        <AppIcon name="compass" className="w-7 h-7 text-primary" />
-        <h1 className="text-2xl font-bold text-foreground">Compliance Journey</h1>
+  const navigate = useNavigate();
+  const user = useAuthStore((s) => s.user);
+  const {
+    stages,
+    currentStageIndex,
+    tasksByStage,
+    loading,
+    setStages,
+    setCurrentStageIndex,
+    setTasksForStage,
+    markTaskCompleted,
+    setLoading,
+  } = useConciergeStore();
+
+  useEffect(() => {
+    if (!user) return;
+
+    async function loadConcierge() {
+      setLoading(true);
+      try {
+        const [stagesData, profile] = await Promise.all([
+          fetchStages(),
+          fetchProfile(user!.id),
+        ]);
+
+        setStages(stagesData);
+
+        // Load tasks for all stages
+        const businessType = profile?.business_type ?? "sole_trader";
+        const headcount = profile?.headcount ?? 1;
+
+        await Promise.all(
+          stagesData.map(async (stage) => {
+            const tasks = await fetchTasksForStage(
+              user!.id,
+              stage.id,
+              businessType,
+              headcount,
+            );
+            setTasksForStage(stage.id, tasks);
+          })
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadConcierge();
+  }, [user, setStages, setTasksForStage, setLoading]);
+
+  const currentStage = stages[currentStageIndex];
+  const currentTasks = useMemo(
+    () => (currentStage ? tasksByStage[currentStage.id] ?? [] : []),
+    [currentStage, tasksByStage]
+  );
+  const progress = currentTasks.length > 0 ? getStageProgress(currentTasks) : null;
+
+  const handleMarkDone = useCallback(
+    async (taskId: string) => {
+      if (!user || !currentStage) return;
+      try {
+        await markTaskDone(user.id, taskId);
+        markTaskCompleted(currentStage.id, taskId);
+      } catch (err) {
+        console.error("Failed to mark task done:", err);
+      }
+    },
+    [user, currentStage, markTaskCompleted]
+  );
+
+  const handleTaskTap = useCallback(
+    (taskId: string) => {
+      const task = currentTasks.find((t) => t.id === taskId);
+      if (!task) return;
+
+      if (task.actionType === "external_link" && task.actionUrl) {
+        window.open(task.actionUrl, "_blank", "noopener");
+      } else if (task.actionType === "internal_workflow" && task.actionUrl) {
+        navigate(task.actionUrl);
+      }
+    },
+    [currentTasks, navigate]
+  );
+
+  // Convert concierge tasks to TaskItemData for TaskList
+  const taskItems: TaskItemData[] = currentTasks.map((task) => ({
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: getTaskStatus(task),
+    completed: task.completed,
+    actionLabel: task.actionType === "external_link" ? "Open" : undefined,
+  }));
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <LoadingSpinner size="lg" message="Loading your journey..." centered />
       </div>
-      <Card padding="lg">
-        <p className="text-muted-foreground">
-          Your guided compliance journey will appear here. Coming soon.
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Compliance Journey</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Complete these tasks to get your business fully compliant
         </p>
-      </Card>
+      </div>
+
+      {/* Stage selector */}
+      <StageSelector
+        stages={stages}
+        currentIndex={currentStageIndex}
+        tasksByStage={tasksByStage}
+        onSelect={setCurrentStageIndex}
+      />
+
+      {/* Stage progress */}
+      {currentStage && progress && (
+        <StageProgress
+          progress={progress}
+          stageName={currentStage.name}
+        />
+      )}
+
+      {/* Stage description */}
+      {currentStage && (
+        <p className="text-sm text-muted-foreground">
+          {currentStage.description}
+        </p>
+      )}
+
+      {/* Task list */}
+      <TaskList
+        tasks={taskItems}
+        variant="checklist"
+        onMarkDone={handleMarkDone}
+        onTap={handleTaskTap}
+        emptyTitle="No tasks for this stage"
+        emptyDescription="Based on your business profile, you don't have any tasks in this stage."
+        emptyIcon="check-circle"
+      />
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
Replaces the placeholder Concierge page with the full guided compliance journey.

### Features
- **StageSelector** — 3-stage tabs with green check when complete, progress counts (X/Y done)
- **StageProgress** — progress bar per stage with "Stage complete!" celebration
- **Task checklist** — TaskList checklist variant with mark-as-done, filtered by business profile
- External link tasks open GOV.UK pages in new tab
- Internal workflow tasks navigate to Calendar/Documents/Dashboard

### Data Flow
ConciergePage → conciergeService (Supabase) → conciergeStore (Zustand) → components

**Note**: This PR includes F-013 (concierge service + seed data) as it was branched from that feature.

Closes #35

## Checks
- **Lint**: clean | **Tests**: 57/57 pass | **Build**: passes

## Test plan
- [ ] 3 stage tabs render with correct names
- [ ] Clicking a stage shows its tasks
- [ ] Sole trader sees different tasks than Ltd company
- [ ] Marking a task done updates progress bar
- [ ] "Stage complete!" shows when all tasks in a stage are done
- [ ] External links (GOV.UK) open in new tab
- [ ] Internal links navigate to correct pages
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)