### PR TITLE
F-015: Compliance Calendar with list/month views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 9 placeholder pages: Landing, Auth, AuthCallback, Onboarding, Dashboard, Concierge, Calendar, Documents, Settings
 - Full route structure: public routes via PublicLayout, protected routes via AppLayout
 - Floating "Ask Advisor" button placeholder in AppLayout
+- Compliance Calendar page with list/month views, task urgency colouring, and mark-as-done (F-015)
+- CalendarHeader with month navigation, today button, and view toggle
+- MonthGrid with coloured urgency dots per day
+- Calendar service and store for fetching/completing tasks
 - Concierge Journey page with stage selector, progress bar, and task checklist (F-014)
 - StageSelector component with completion indicators and progress counts
 - StageProgress component with percentage bar and stage complete celebration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ src/
 │   ├── layout/     # AppLayout, Sidebar, PublicLayout, MobileNav
 │   ├── auth/       # ProtectedRoute, AuthProvider, MagicLinkSent
 │   ├── dashboard/  # DomainBreakdown, NextActions
+│   ├── calendar/   # CalendarHeader, MonthGrid
 │   ├── concierge/  # StageSelector, StageProgress
 │   ├── settings/   # SettingsCard, SettingsField, SettingsToggle, AvatarUpload
 │   ├── landing/    # LandingNav, HeroHealthCard, EmailSignup, PricingCard, etc.

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,6 +82,13 @@ Settings components in `src/components/settings/`:
 | `SettingsToggle` | Toggle switch with label + description |
 | `AvatarUpload` | Drag-drop image upload with zoom/reposition |
 
+Calendar components in `src/components/calendar/`:
+
+| Component | Use case |
+|-----------|----------|
+| `CalendarHeader` | Month/year navigation, today button, list/month view toggle |
+| `MonthGrid` | Month grid view with coloured urgency dots per day |
+
 ### Adding New shadcn Components
 
 ```bash

--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,107 @@
+import { cn } from '@/lib/utils'
+import { Button, AppIcon } from '@/components/ui'
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+interface CalendarHeaderProps {
+  month: number
+  year: number
+  viewMode: 'list' | 'month'
+  onPreviousMonth: () => void
+  onNextMonth: () => void
+  onToday: () => void
+  onViewModeChange: (mode: 'list' | 'month') => void
+  className?: string
+}
+
+export default function CalendarHeader({
+  month,
+  year,
+  viewMode,
+  onPreviousMonth,
+  onNextMonth,
+  onToday,
+  onViewModeChange,
+  className,
+}: CalendarHeaderProps) {
+  const now = new Date()
+  const isCurrentMonth =
+    month === now.getMonth() + 1 && year === now.getFullYear()
+
+  return (
+    <div className={cn('flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between', className)}>
+      {/* Month navigation */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onPreviousMonth}
+          className="p-2 rounded-lg border border-border hover:bg-surface transition-colors"
+          aria-label="Previous month"
+        >
+          <AppIcon name="chevron-left" className="w-4 h-4 text-foreground" />
+        </button>
+
+        <h2 className="text-lg font-bold text-foreground min-w-[180px] text-center">
+          {MONTH_NAMES[month - 1]} {year}
+        </h2>
+
+        <button
+          type="button"
+          onClick={onNextMonth}
+          className="p-2 rounded-lg border border-border hover:bg-surface transition-colors"
+          aria-label="Next month"
+        >
+          <AppIcon name="chevron-right" className="w-4 h-4 text-foreground" />
+        </button>
+
+        {!isCurrentMonth && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onToday}
+            className="text-xs"
+          >
+            Today
+          </Button>
+        )}
+      </div>
+
+      {/* View toggle */}
+      <div className="flex items-center gap-1 rounded-lg border border-border p-1 self-start sm:self-auto">
+        <button
+          type="button"
+          onClick={() => onViewModeChange('list')}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-colors',
+            viewMode === 'list'
+              ? 'bg-primary text-white'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          aria-label="List view"
+          aria-pressed={viewMode === 'list'}
+        >
+          <AppIcon name="list-check" className="w-3.5 h-3.5" />
+          List
+        </button>
+        <button
+          type="button"
+          onClick={() => onViewModeChange('month')}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-colors',
+            viewMode === 'month'
+              ? 'bg-primary text-white'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          aria-label="Month view"
+          aria-pressed={viewMode === 'month'}
+        >
+          <AppIcon name="calendar-days" className="w-3.5 h-3.5" />
+          Month
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -1,0 +1,114 @@
+import { cn } from '@/lib/utils'
+import type { CalendarTaskWithDomain } from '@/services/calendarService'
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const URGENCY_DOT_CLASS = {
+  red: 'bg-status-red',
+  amber: 'bg-status-amber',
+  green: 'bg-status-green',
+} as const
+
+interface MonthGridProps {
+  month: number
+  year: number
+  tasks: CalendarTaskWithDomain[]
+  className?: string
+}
+
+export default function MonthGrid({ month, year, tasks, className }: MonthGridProps) {
+  const firstDay = new Date(year, month - 1, 1)
+  const lastDay = new Date(year, month, 0)
+  const daysInMonth = lastDay.getDate()
+
+  // Monday = 0, Sunday = 6
+  let startDayOfWeek = firstDay.getDay() - 1
+  if (startDayOfWeek < 0) startDayOfWeek = 6
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const isCurrentMonth = month === today.getMonth() + 1 && year === today.getFullYear()
+
+  // Group tasks by day number
+  const tasksByDay = new Map<number, CalendarTaskWithDomain[]>()
+  for (const task of tasks) {
+    const taskDate = new Date(task.due_date)
+    const day = taskDate.getDate()
+    const existing = tasksByDay.get(day) ?? []
+    existing.push(task)
+    tasksByDay.set(day, existing)
+  }
+
+  // Build grid cells: leading empty + days of month
+  const cells: (number | null)[] = []
+  for (let i = 0; i < startDayOfWeek; i++) cells.push(null)
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d)
+
+  return (
+    <div className={cn('border border-border rounded-xl overflow-hidden', className)}>
+      {/* Day name headers */}
+      <div className="grid grid-cols-7 bg-surface">
+        {DAY_NAMES.map((name) => (
+          <div key={name} className="py-2 text-center text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            {name}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7">
+        {cells.map((day, idx) => {
+          const dayTasks = day ? tasksByDay.get(day) ?? [] : []
+          const isToday = isCurrentMonth && day === today.getDate()
+
+          return (
+            <div
+              key={idx}
+              className={cn(
+                'min-h-[64px] sm:min-h-[80px] border-t border-l border-border p-1.5 sm:p-2',
+                idx % 7 === 0 && 'border-l-0',
+                !day && 'bg-surface/50',
+              )}
+            >
+              {day != null && (
+                <>
+                  <span
+                    className={cn(
+                      'inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-semibold',
+                      isToday
+                        ? 'bg-primary text-white'
+                        : 'text-foreground',
+                    )}
+                  >
+                    {day}
+                  </span>
+                  {dayTasks.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {dayTasks.slice(0, 3).map((task) => (
+                        <span
+                          key={task.id}
+                          className={cn(
+                            'w-2 h-2 rounded-full shrink-0',
+                            task.completed
+                              ? 'bg-muted-foreground/30'
+                              : URGENCY_DOT_CLASS[task.urgency],
+                          )}
+                          title={task.title}
+                        />
+                      ))}
+                      {dayTasks.length > 3 && (
+                        <span className="text-[10px] text-muted-foreground leading-none">
+                          +{dayTasks.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,17 +1,179 @@
-import { Card, AppIcon } from '@/components/ui'
+import { useEffect, useCallback } from 'react'
+import { AppIcon, LoadingSpinner, EmptyState } from '@/components/ui'
+import { useAuthStore } from '@/stores/authStore'
+import { useCalendarStore } from '@/stores/calendarStore'
+import {
+  fetchCalendarTasks,
+  markCalendarTaskComplete,
+} from '@/services/calendarService'
+import CalendarHeader from '@/components/calendar/CalendarHeader'
+import MonthGrid from '@/components/calendar/MonthGrid'
+import TaskList from '@/components/shared/TaskList'
+import type { TaskItemData } from '@/components/shared/TaskItem'
+
+/**
+ * Format a date string (YYYY-MM-DD) into a readable label like "Mon 14 Apr".
+ */
+function formatDateLabel(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  return date.toLocaleDateString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  })
+}
+
+/**
+ * Group tasks by their due date for the list view.
+ */
+function groupTasksByDate(
+  tasks: TaskItemData[],
+  rawDates: Map<string, string>,
+): { date: string; label: string; tasks: TaskItemData[] }[] {
+  const groups = new Map<string, TaskItemData[]>()
+
+  for (const task of tasks) {
+    const rawDate = rawDates.get(task.id) ?? ''
+    const existing = groups.get(rawDate) ?? []
+    existing.push(task)
+    groups.set(rawDate, existing)
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, dateTasks]) => ({
+      date,
+      label: formatDateLabel(date),
+      tasks: dateTasks,
+    }))
+}
 
 export default function CalendarPage() {
+  const user = useAuthStore((s) => s.user)
+  const {
+    tasks,
+    viewMode,
+    selectedMonth,
+    selectedYear,
+    loading,
+    setTasks,
+    setViewMode,
+    setLoading,
+    goToPreviousMonth,
+    goToNextMonth,
+    goToToday,
+  } = useCalendarStore()
+
+  const loadTasks = useCallback(async () => {
+    if (!user) return
+    setLoading(true)
+    try {
+      const data = await fetchCalendarTasks(user.id, {
+        month: selectedMonth,
+        year: selectedYear,
+      })
+      setTasks(data)
+    } catch (err) {
+      console.error('Failed to load calendar tasks:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [user, selectedMonth, selectedYear, setTasks, setLoading])
+
+  useEffect(() => {
+    loadTasks()
+  }, [loadTasks])
+
+  const handleMarkDone = useCallback(
+    async (taskId: string) => {
+      try {
+        await markCalendarTaskComplete(taskId)
+        await loadTasks()
+      } catch (err) {
+        console.error('Failed to mark task complete:', err)
+      }
+    },
+    [loadTasks],
+  )
+
+  // Convert CalendarTaskWithDomain into TaskItemData for TaskList
+  const taskItems: TaskItemData[] = tasks.map((t) => ({
+    id: t.id,
+    title: t.title,
+    description: t.domainName
+      ? `${t.domainName} — ${t.description ?? ''}`
+      : t.description ?? undefined,
+    status: t.urgency,
+    dueDate: formatDateLabel(t.due_date),
+    completed: t.completed,
+  }))
+
+  // Keep a map of task ID -> raw date for grouping
+  const rawDatesMap = new Map(tasks.map((t) => [t.id, t.due_date]))
+
+  const dateGroups = groupTasksByDate(taskItems, rawDatesMap)
+
   return (
-    <div>
+    <div className="bg-page min-h-full">
+      {/* Page header */}
       <div className="flex items-center gap-3 mb-6">
         <AppIcon name="calendar" className="w-7 h-7 text-primary" />
-        <h1 className="text-2xl font-bold text-foreground">Compliance Calendar</h1>
+        <h1 className="text-2xl font-bold text-foreground">
+          Compliance Calendar
+        </h1>
       </div>
-      <Card padding="lg">
-        <p className="text-muted-foreground">
-          Your statutory deadlines and compliance tasks will appear here. Coming soon.
-        </p>
-      </Card>
+
+      {/* Calendar header with navigation and view toggle */}
+      <CalendarHeader
+        month={selectedMonth}
+        year={selectedYear}
+        viewMode={viewMode}
+        onPreviousMonth={goToPreviousMonth}
+        onNextMonth={goToNextMonth}
+        onToday={goToToday}
+        onViewModeChange={setViewMode}
+        className="mb-6"
+      />
+
+      {/* Content */}
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <LoadingSpinner size="lg" />
+        </div>
+      ) : viewMode === 'month' ? (
+        /* ── Month grid view ── */
+        <MonthGrid
+          month={selectedMonth}
+          year={selectedYear}
+          tasks={tasks}
+        />
+      ) : tasks.length === 0 ? (
+        /* ── Empty state ── */
+        <EmptyState
+          icon="calendar"
+          title="No deadlines this month"
+          description="You have no compliance tasks due this month. Use the arrows to check other months."
+        />
+      ) : (
+        /* ── List view grouped by date ── */
+        <div className="flex flex-col gap-6">
+          {dateGroups.map((group) => (
+            <div key={group.date}>
+              <p className="text-[10px] font-bold uppercase tracking-[0.8px] text-muted-foreground mb-3">
+                {group.label}
+              </p>
+              <TaskList
+                tasks={group.tasks}
+                variant="timeline"
+                onMarkDone={handleMarkDone}
+                emptyTitle="No deadlines this month"
+                emptyDescription="You have no compliance tasks due this month."
+                emptyIcon="calendar"
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -1,0 +1,112 @@
+import { supabase } from '@/lib/supabase'
+import type { CalendarTask, HealthStatus } from '@/types'
+
+export interface CalendarTaskWithDomain extends CalendarTask {
+  domainName: string | null
+  urgency: HealthStatus
+}
+
+/**
+ * Calculate urgency status based on due date relative to today.
+ * Red = overdue, Amber = due within 14 days, Green = more than 14 days out.
+ */
+export function getTaskUrgency(dueDate: string): HealthStatus {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const due = new Date(dueDate)
+  due.setHours(0, 0, 0, 0)
+  const diffMs = due.getTime() - today.getTime()
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffDays < 0) return 'red'
+  if (diffDays <= 14) return 'amber'
+  return 'green'
+}
+
+/**
+ * Fetch calendar tasks for a user, optionally filtered by month/year.
+ * Joins compliance_domains to get the domain name.
+ */
+export async function fetchCalendarTasks(
+  userId: string,
+  options?: { month?: number; year?: number },
+): Promise<CalendarTaskWithDomain[]> {
+  let query = supabase
+    .from('task_calendar')
+    .select(`
+      *,
+      compliance_domains(name)
+    `)
+    .eq('user_id', userId)
+    .order('due_date', { ascending: true })
+
+  if (options?.month != null && options?.year != null) {
+    const startDate = `${options.year}-${String(options.month).padStart(2, '0')}-01`
+    const lastDay = new Date(options.year, options.month, 0).getDate()
+    const endDate = `${options.year}-${String(options.month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+    query = query.gte('due_date', startDate).lte('due_date', endDate)
+  }
+
+  const { data, error } = await query
+
+  if (error) throw error
+  if (!data) return []
+
+  return data.map(task => {
+    const domainData = task.compliance_domains as unknown as { name: string } | null
+    return {
+      ...task,
+      compliance_domains: undefined,
+      domainName: domainData?.name ?? null,
+      urgency: getTaskUrgency(task.due_date),
+    } as CalendarTaskWithDomain
+  })
+}
+
+/**
+ * Mark a calendar task as complete.
+ */
+export async function markCalendarTaskComplete(taskId: string): Promise<void> {
+  const { error } = await supabase
+    .from('task_calendar')
+    .update({
+      completed: true,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', taskId)
+
+  if (error) throw error
+}
+
+/**
+ * Fetch all overdue, incomplete tasks for a user.
+ */
+export async function getOverdueTasks(
+  userId: string,
+): Promise<CalendarTaskWithDomain[]> {
+  const today = new Date().toISOString().split('T')[0]
+
+  const { data, error } = await supabase
+    .from('task_calendar')
+    .select(`
+      *,
+      compliance_domains(name)
+    `)
+    .eq('user_id', userId)
+    .eq('completed', false)
+    .lt('due_date', today)
+    .order('due_date', { ascending: true })
+
+  if (error) throw error
+  if (!data) return []
+
+  return data.map(task => {
+    const domainData = task.compliance_domains as unknown as { name: string } | null
+    return {
+      ...task,
+      compliance_domains: undefined,
+      domainName: domainData?.name ?? null,
+      urgency: 'red' as HealthStatus,
+    } as CalendarTaskWithDomain
+  })
+}

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand'
+import type { CalendarTaskWithDomain } from '@/services/calendarService'
+
+type ViewMode = 'list' | 'month'
+
+interface CalendarState {
+  tasks: CalendarTaskWithDomain[]
+  viewMode: ViewMode
+  selectedMonth: number
+  selectedYear: number
+  loading: boolean
+  setTasks: (tasks: CalendarTaskWithDomain[]) => void
+  setViewMode: (mode: ViewMode) => void
+  setSelectedMonth: (month: number) => void
+  setSelectedYear: (year: number) => void
+  setLoading: (loading: boolean) => void
+  goToPreviousMonth: () => void
+  goToNextMonth: () => void
+  goToToday: () => void
+}
+
+const now = new Date()
+
+export const useCalendarStore = create<CalendarState>((set) => ({
+  tasks: [],
+  viewMode: 'list',
+  selectedMonth: now.getMonth() + 1,
+  selectedYear: now.getFullYear(),
+  loading: true,
+  setTasks: (tasks) => set({ tasks }),
+  setViewMode: (viewMode) => set({ viewMode }),
+  setSelectedMonth: (selectedMonth) => set({ selectedMonth }),
+  setSelectedYear: (selectedYear) => set({ selectedYear }),
+  setLoading: (loading) => set({ loading }),
+  goToPreviousMonth: () =>
+    set((state) => {
+      if (state.selectedMonth === 1) {
+        return { selectedMonth: 12, selectedYear: state.selectedYear - 1 }
+      }
+      return { selectedMonth: state.selectedMonth - 1 }
+    }),
+  goToNextMonth: () =>
+    set((state) => {
+      if (state.selectedMonth === 12) {
+        return { selectedMonth: 1, selectedYear: state.selectedYear + 1 }
+      }
+      return { selectedMonth: state.selectedMonth + 1 }
+    }),
+  goToToday: () =>
+    set({
+      selectedMonth: new Date().getMonth() + 1,
+      selectedYear: new Date().getFullYear(),
+    }),
+}))


### PR DESCRIPTION
## Summary
- Calendar page with list view (tasks grouped by date) and month grid view (urgency dots)
- CalendarHeader with month/year navigation, today button, list/month toggle
- MonthGrid with coloured urgency dots (red/amber/green) per day
- Calendar service: fetchCalendarTasks, markCalendarTaskComplete, getOverdueTasks
- Calendar store (Zustand): tasks, viewMode, selectedMonth/Year, navigation actions
- List view uses TaskList timeline variant with mark-as-done

Closes #38

## Checks
- **Lint**: clean | **Tests**: 57/57 pass | **Build**: passes

## Test plan
- [ ] Calendar shows tasks seeded during onboarding
- [ ] Month navigation works (prev/next/today)
- [ ] List view: tasks grouped by date with urgency colours
- [ ] Month view: dots on days with tasks
- [ ] Mark as done removes task from upcoming
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)